### PR TITLE
Get available hearts per question

### DIFF
--- a/src/api/fetchForumQuestionHearts.ts
+++ b/src/api/fetchForumQuestionHearts.ts
@@ -1,0 +1,24 @@
+async function fetchForumQuestionHearts(questionId: string): Promise<number | null> {
+  try {
+    const response = await fetch(
+      `${import.meta.env.VITE_SERVER_URL}/api/forum-questions/${questionId}/hearts`,
+      {
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP Error! Status: ${response.status}`);
+    }
+
+    const hearts = (await response.json()) as { data: number };
+    return hearts.data;
+  } catch (error) {
+    console.error('Error fetching forum question statistics:', error);
+    return null;
+  }
+}
+
+export default fetchForumQuestionHearts;

--- a/src/api/fetchUserVotes.ts
+++ b/src/api/fetchUserVotes.ts
@@ -2,11 +2,13 @@ import { ResponseUserVotesType } from '../types/CycleType';
 
 async function fetchUserVotes(
   userId: string,
-  cycleId: string
+  forumQuestionId: string
 ): Promise<ResponseUserVotesType | null> {
   try {
     const response = await fetch(
-      `${import.meta.env.VITE_SERVER_URL}/api/users/${userId}/cycles/${cycleId}/votes`,
+      `${
+        import.meta.env.VITE_SERVER_URL
+      }/api/users/${userId}/forum-questions/${forumQuestionId}/votes`,
       {
         credentials: 'include',
         headers: {
@@ -21,7 +23,7 @@ async function fetchUserVotes(
     const userVotes = (await response.json()) as { data: ResponseUserVotesType };
     return userVotes.data;
   } catch (error) {
-    console.error('Error fetchin user votes:', error);
+    console.error('Error fetching user votes:', error);
     return null;
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,3 +11,4 @@ export { default as postRegistrationData } from './postRegistrationData';
 export { default as fetchEventCycles } from './fetchEventCycles';
 export { default as fetchEvent } from './fetchEvent';
 export { default as fetchForumQuestionStatistics } from './fetchForumQuestionStatistics';
+export { default as fetchForumQuestionHearts } from './fetchForumQuestionHearts';

--- a/src/components/option/Option.tsx
+++ b/src/components/option/Option.tsx
@@ -6,13 +6,13 @@ import { Body, StyledOption, Title } from './Option.styled';
 type OptionProps = {
   title: string;
   body?: string;
-  avaliableHearts: number;
+  availableHearts: number;
   numOfVotes: number;
   onVote: () => void;
   onUnvote: () => void;
 };
 
-function Option({ title, body, avaliableHearts, numOfVotes, onVote, onUnvote }: OptionProps) {
+function Option({ title, body, availableHearts, numOfVotes, onVote, onUnvote }: OptionProps) {
   const [localOptionHearts, setLocalOptionHearts] = useState(numOfVotes);
 
   useEffect(() => {
@@ -20,7 +20,7 @@ function Option({ title, body, avaliableHearts, numOfVotes, onVote, onUnvote }: 
   }, [numOfVotes]);
 
   const handleVoteClick = () => {
-    if (avaliableHearts) {
+    if (availableHearts) {
       setLocalOptionHearts((prevLocalOptionHearts) => prevLocalOptionHearts + 1);
       onVote();
     }
@@ -56,7 +56,7 @@ function Option({ title, body, avaliableHearts, numOfVotes, onVote, onUnvote }: 
             >
               Unvote
             </Button>
-            <Button color="primary" onClick={handleVoteClick} disabled={avaliableHearts === 0}>
+            <Button color="primary" onClick={handleVoteClick} disabled={availableHearts === 0}>
               Vote
             </Button>
           </FlexRow>

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -50,7 +50,7 @@ function Vote() {
     retry: false,
   });
 
-  const [availableHearts, setAvailableHearts] = useState(initialHearts ?? 0);
+  const [availableHearts, setAvailableHearts] = useState(0);
   const [localUserVotes, setLocalUserVotes] = useState<
     ResponseUserVotesType | { optionId: string; numOfVotes: number }[]
   >([]);
@@ -68,7 +68,6 @@ function Vote() {
     const givenVotes = votes
       .map((option) => option.numOfVotes)
       .reduce((prev, curr) => prev + curr, 0);
-
     setAvailableHearts(initialHearts - givenVotes);
     setLocalUserVotes(votes);
   };
@@ -91,7 +90,7 @@ function Vote() {
   }, [localUserVotes, userVotes]);
 
   useEffect(() => {
-    if (userVotes?.length && initialHearts) {
+    if (userVotes && initialHearts) {
       updateVotesAndHearts(userVotes, initialHearts);
     }
   }, [userVotes, initialHearts]);

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -41,7 +41,7 @@ function Vote() {
   });
 
   const initialHearts = 10;
-  const [avaliableHearts, setAvaliableHearts] = useState(initialHearts);
+  const [availableHearts, setAvailableHearts] = useState(initialHearts);
   const [localUserVotes, setLocalUserVotes] = useState<
     ResponseUserVotesType | { optionId: string; numOfVotes: number }[]
   >([]);
@@ -60,7 +60,7 @@ function Vote() {
       .map((option) => option.numOfVotes)
       .reduce((prev, curr) => prev + curr, 0);
 
-    setAvaliableHearts(initialHearts - givenVotes);
+    setAvailableHearts(initialHearts - givenVotes);
     setLocalUserVotes(votes);
   };
 
@@ -88,7 +88,7 @@ function Vote() {
   }, [userVotes]);
 
   const handleVote = (optionId: string) => {
-    if (avaliableHearts > 0) {
+    if (availableHearts > 0) {
       setLocalUserVotes((prevLocalUserVotes) => {
         const temp = prevLocalUserVotes.find((x) => x.optionId === optionId);
         if (!temp) {
@@ -102,7 +102,7 @@ function Vote() {
         });
         return updatedLocalVotes;
       });
-      setAvaliableHearts((prevAvaliableHearts) => Math.max(0, prevAvaliableHearts - 1));
+      setAvailableHearts((prevAvailableHearts) => Math.max(0, prevAvailableHearts - 1));
     }
   };
 
@@ -119,7 +119,7 @@ function Vote() {
       return updatedLocalVotes;
     });
 
-    setAvaliableHearts((prevAvaliableHearts) => Math.min(initialHearts, prevAvaliableHearts + 1));
+    setAvailableHearts((prevAvailableHearts) => Math.min(initialHearts, prevAvailableHearts + 1));
   };
 
   const { mutate: mutateVote } = useMutation({
@@ -171,10 +171,10 @@ function Vote() {
             {Array.from({ length: initialHearts }).map((_, id) => (
               <img
                 key={id}
-                src={id < avaliableHearts ? '/icons/full_heart.svg' : '/icons/empty_heart.svg'}
+                src={id < availableHearts ? '/icons/full_heart.svg' : '/icons/empty_heart.svg'}
                 height={32}
                 width={32}
-                alt={id < avaliableHearts ? 'Full Heart' : 'Empty Heart'}
+                alt={id < availableHearts ? 'Full Heart' : 'Empty Heart'}
               />
             ))}
           </FlexRow>
@@ -193,7 +193,7 @@ function Vote() {
                 <Option
                   key={questionOption.id}
                   title={questionOption.text}
-                  avaliableHearts={avaliableHearts}
+                  availableHearts={availableHearts}
                   numOfVotes={numOfVotes}
                   onVote={() => handleVote(questionOption.id)}
                   onUnvote={() => handleUnvote(questionOption.id)}


### PR DESCRIPTION
# overview
- adds fetchForumQuestionHearts to vote page to handle the total amount of hearts to show
-  includes new backend route that brings votes per question instead of per cycle