### PR TITLE
Diego/routing improvement

### DIFF
--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -1,6 +1,6 @@
 // React and third-party libraries
 import { ReactNode, useEffect, useMemo } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, RouterProvider, Routes, createBrowserRouter } from 'react-router-dom';
 
 // Hooks
 import useUser from './hooks/useUser';
@@ -18,7 +18,24 @@ import Register from './pages/Register';
 import { useQuery } from '@tanstack/react-query';
 import { fetchEvents } from 'api';
 
+// Components
+import BerlinLayout from './layout/index.ts';
+
+const router = createBrowserRouter([
+  {
+    element: <BerlinLayout />,
+    children: [
+      { path: '*', Component: Root },
+      { path: '/onboarding', Component: Onboarding },
+    ],
+  },
+]);
+
 function App() {
+  return <RouterProvider router={router}></RouterProvider>;
+}
+
+function Root() {
   const { user, isLoading } = useUser();
 
   const { data: events } = useQuery({
@@ -66,7 +83,6 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={handleHomePage} />
-      <Route path="/onboarding" element={user ? <Onboarding /> : <Navigate to="/" replace />} />
       <Route path="/account" element={user ? <Account /> : <Navigate to="/" replace />} />
       <Route
         path="/events/:eventId/register"

--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -1,5 +1,7 @@
 // React and third-party libraries
 import { RouterProvider, createBrowserRouter, redirect } from 'react-router-dom';
+import { fetchEvents, fetchUserData } from 'api';
+import { QueryClient } from '@tanstack/react-query';
 
 // Hooks
 
@@ -7,17 +9,13 @@ import { RouterProvider, createBrowserRouter, redirect } from 'react-router-dom'
 import { useAppStore } from './store';
 
 // Pages
-import { fetchEvents, fetchUserData } from 'api';
 import Account from './pages/Account';
 import Holding from './pages/Holding';
 import Landing from './pages/Landing';
 import Onboarding from './pages/Onboarding';
 import PassportPopupRedirect from './pages/Popup';
 import Register from './pages/Register';
-
-// Components
 import { default as BerlinLayout } from './layout/index.ts';
-import { QueryClient } from '@tanstack/react-query';
 
 async function protectedLoader(queryClient: QueryClient) {
   const user = await queryClient.fetchQuery({

--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -37,39 +37,33 @@ async function landingLoader(queryClient: QueryClient) {
   const user = await queryClient.fetchQuery({
     queryKey: ['user'],
     queryFn: fetchUserData,
+    retry: 3,
   });
   const events = await queryClient.fetchQuery({
     queryKey: ['events'],
     queryFn: fetchEvents,
   });
 
-  console.log('in the beginning');
   if (!user) {
-    console.log('no user');
     return null;
   }
 
   if (appState.userStatus === 'INCOMPLETE' && user?.username) {
-    console.log('user incomplete and should be complete');
     useAppStore.setState({ userStatus: 'COMPLETE' });
   }
 
   if (appState.onboardingStatus === 'INCOMPLETE') {
-    console.log('onboarding incomplete');
     return redirect('/onboarding');
   }
 
   if (appState.userStatus === 'INCOMPLETE') {
-    console.log('user incomplete');
     return redirect('/account');
   }
 
   if (events?.length === 1) {
-    console.log('redirecting to event');
     return redirect(`/events/${events?.[0].id}/register`);
   }
 
-  console.log('no redirect');
   return null;
 }
 

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -58,10 +58,8 @@ function Header() {
 
   const [isBurgerMenuOpen, setIsBurgerMenuOpen] = useState(false);
 
-  // Define onClick handler to navigate to account page and trigger reload
   const handleAccountClick = () => {
     navigate('/account');
-    window.location.reload();
   };
 
   return (

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -1,7 +1,7 @@
 // React and third-party libraries
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { redirect, useNavigate } from 'react-router-dom';
 
 // Store
 import { useAppStore } from '../../store';
@@ -52,6 +52,7 @@ function Header() {
       resetState();
       await queryClient.invalidateQueries();
       await queryClient.removeQueries();
+      redirect('/');
     },
   });
 

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -1,7 +1,7 @@
 // React and third-party libraries
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { redirect, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 // Store
 import { useAppStore } from '../../store';
@@ -52,7 +52,7 @@ function Header() {
       resetState();
       await queryClient.invalidateQueries();
       await queryClient.removeQueries();
-      redirect('/');
+      navigate('/');
     },
   });
 

--- a/packages/berlin/src/components/select/Select.tsx
+++ b/packages/berlin/src/components/select/Select.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Dropdown,
   ErrorsContainer,
@@ -43,6 +43,12 @@ function Select({
     options.find((o) => o.id === value)?.name,
   );
   const [creatableOption, setCreatableOption] = useState<string>('');
+
+  useEffect(() => {
+    if (value) {
+      setSelectedOption(options.find((o) => o.id === value)?.name);
+    }
+  }, [value, options]);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const inputText = event.target.value;

--- a/packages/berlin/src/components/zupassButton/ZupassLoginButton.tsx
+++ b/packages/berlin/src/components/zupassButton/ZupassLoginButton.tsx
@@ -11,6 +11,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postPcdStr } from 'api';
 import { useEffect, useState } from 'react';
 import Button from '../button';
+import { useNavigate } from 'react-router-dom';
 
 type ZupassLoginButtonProps = {
   $variant?: 'contained' | 'link';
@@ -20,6 +21,7 @@ type ZupassLoginButtonProps = {
 const POPUP_URL = window.location.origin + '/popup';
 
 function ZupassLoginButton({ children, $variant, ...props }: ZupassLoginButtonProps) {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   const { mutate: mutateVerify } = useMutation({
@@ -27,6 +29,7 @@ function ZupassLoginButton({ children, $variant, ...props }: ZupassLoginButtonPr
     onSuccess: (body) => {
       if (body) {
         queryClient.invalidateQueries({ queryKey: ['user'] });
+        navigate('/');
       }
     },
   });

--- a/packages/berlin/src/components/zupassButton/ZupassLoginButton.tsx
+++ b/packages/berlin/src/components/zupassButton/ZupassLoginButton.tsx
@@ -1,16 +1,15 @@
 import {
+  SignInMessagePayload,
   openSignedZuzaluSignInPopup,
+  requestUser,
   usePCDMultiplexer,
   usePendingPCD,
   useSemaphoreSignatureProof,
   useZupassPopupMessages,
-  SignInMessagePayload,
-  requestUser,
 } from '@pcd/passport-interface';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { postPcdStr } from 'api';
+import { useEffect, useState } from 'react';
 import Button from '../button';
 
 type ZupassLoginButtonProps = {
@@ -22,14 +21,12 @@ const POPUP_URL = window.location.origin + '/popup';
 
 function ZupassLoginButton({ children, $variant, ...props }: ZupassLoginButtonProps) {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
 
   const { mutate: mutateVerify } = useMutation({
     mutationFn: postPcdStr,
     onSuccess: (body) => {
       if (body) {
         queryClient.invalidateQueries({ queryKey: ['user'] });
-        navigate('/');
       }
     },
   });
@@ -43,7 +40,7 @@ function ZupassLoginButton({ children, $variant, ...props }: ZupassLoginButtonPr
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_, __, serverPCDStr] = usePendingPCD(
     zupassPendingPCDStr,
-    import.meta.env.VITE_ZUPASS_SERVER_URL
+    import.meta.env.VITE_ZUPASS_SERVER_URL,
   );
   const pcdStr = usePCDMultiplexer(zupassPCDStr, serverPCDStr);
 

--- a/packages/berlin/src/layout/Layout.tsx
+++ b/packages/berlin/src/layout/Layout.tsx
@@ -1,5 +1,6 @@
 // React and third-party libraries
 import { Toaster } from 'react-hot-toast';
+import { Outlet } from 'react-router-dom';
 
 // Components
 import Header from '../components/header';
@@ -7,7 +8,6 @@ import Footer from '../components/footer';
 
 // Styled components
 import { Main } from './Layout.styled';
-import { Outlet } from 'react-router-dom';
 
 function Layout() {
   return (

--- a/packages/berlin/src/layout/Layout.tsx
+++ b/packages/berlin/src/layout/Layout.tsx
@@ -7,17 +7,16 @@ import Footer from '../components/footer';
 
 // Styled components
 import { Main } from './Layout.styled';
+import { Outlet } from 'react-router-dom';
 
-type LayoutProps = {
-  children: React.ReactNode;
-};
-
-function Layout({ children }: LayoutProps) {
+function Layout() {
   return (
     <>
       <Toaster position="top-center" />
       <Header />
-      <Main>{children}</Main>
+      <Main>
+        <Outlet />
+      </Main>
       <Footer />
     </>
   );

--- a/packages/berlin/src/main.tsx
+++ b/packages/berlin/src/main.tsx
@@ -13,7 +13,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemedApp>
-        <BerlinApp />
+        <BerlinApp queryClient={queryClient} />
       </ThemedApp>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/packages/berlin/src/main.tsx
+++ b/packages/berlin/src/main.tsx
@@ -1,27 +1,21 @@
 // React and third-party libraries
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import BerlinApp from './App.tsx';
-import BerlinLayout from './layout/index.ts';
-import ThemedApp from './global.styled.tsx';
+import ThemedApp from './global.styled';
 
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <ThemedApp>
-          <BerlinLayout>
-            <BerlinApp />
-          </BerlinLayout>
-        </ThemedApp>
-        <ReactQueryDevtools initialIsOpen={false} />
-      </QueryClientProvider>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <ThemedApp>
+        <BerlinApp />
+      </ThemedApp>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -35,6 +35,7 @@ import { formatGroups } from '../utils/formatGroups';
 // Store
 import { useAppStore } from '../store';
 import { Body } from '../components/typography/Body.styled';
+import { useEffect, useMemo } from 'react';
 
 const ACADEMIC_CREDENTIALS = ['Bachelors', 'Masters', 'PhD', 'JD', 'None'];
 
@@ -172,11 +173,16 @@ function AccountForm({
     formState: { errors, isValid },
     handleSubmit,
     setValue,
+    reset,
     trigger,
   } = useForm({
-    defaultValues: initialUser,
+    defaultValues: useMemo(() => initialUser, [initialUser]),
     mode: 'all',
   });
+
+  useEffect(() => {
+    reset(initialUser);
+  }, [initialUser, reset]);
 
   const {
     fields: fieldsCredentialsGroup,

--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -271,7 +271,6 @@ function AccountForm({
     trigger('userAttributes.customGroupName');
   };
 
-  console.log(watchedGroupInputId, customGroup?.id);
   return (
     <FlexColumn>
       <Title>Complete your registration</Title>
@@ -298,7 +297,7 @@ function AccountForm({
                     id: group.id,
                   }))}
                   label="Affiliation"
-                  placeholder="Select an affiliation"
+                  placeholder={field.value ? field.value : 'Select or create affiliation'}
                   required
                   onChange={field.onChange}
                   onBlur={field.onBlur}

--- a/packages/berlin/src/pages/Holding.tsx
+++ b/packages/berlin/src/pages/Holding.tsx
@@ -11,10 +11,8 @@ function Holding() {
   const navigate = useNavigate();
   const { eventId } = useParams();
 
-  // Define onClick handler to navigate to registration page and trigger reload
   const handleRegistrationClick = () => {
     navigate(`/events/${eventId}/register`);
-    window.location.reload();
   };
 
   return (

--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -74,6 +74,16 @@ function Register() {
   );
 }
 
+const getDefaultValues = (registrationData: GetRegistrationDataResponse | null | undefined) => {
+  return registrationData?.reduce(
+    (acc, curr) => {
+      acc[curr.registrationFieldId] = curr.value;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+};
+
 function RegisterForm(props: {
   user: AuthUser | null | undefined;
   registrationFields?: GetRegistrationFieldsResponse | null | undefined;
@@ -90,16 +100,18 @@ function RegisterForm(props: {
     control,
     handleSubmit,
     getValues,
+    reset,
   } = useForm({
-    defaultValues: props.registrationData?.reduce(
-      (acc, curr) => {
-        acc[curr.registrationFieldId] = curr.value;
-        return acc;
-      },
-      {} as Record<string, string>,
+    defaultValues: useMemo(
+      () => getDefaultValues(props.registrationData),
+      [props.registrationData],
     ),
     mode: 'onBlur',
   });
+
+  useEffect(() => {
+    reset(getDefaultValues(props.registrationData));
+  }, [props.registrationData, reset]);
 
   const values = getValues();
 


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-frontend/issues/199
closes https://github.com/lexicongovernance/pluraltools-frontend/issues/138

## overview
- migrates Routes to CreateBrowserRouter
- adds protected routes
- fixes form having old data

### why migrate to CreateBrowserRouter?
- it is the latest way to create routers with react router
- allows us to decouple the routes and the redirection logic which can be seen in landing loader
- allows us to have a stronger protection on authenticated routes

### why did we have outdated data in the forms?
the way react-hook-form works is that it receives the initial data and will automatically render that and will not watch if that initial data changes. So what would happen is that before our information would update the form would already have populated old data and would not care if a prop changes. To fix this we use a mix of useMemo and UseEffect with `reset` from the hook. UseEffect is to watch when the prop changes and useMemo is to not to extra calculation if the prop is the same as it was before. [inspiration](https://stackoverflow.com/questions/62242657/how-to-change-react-hook-form-defaultvalue-with-useeffect)

### side effects
- had to move layout to App.tsx and it will contain all children routes. This is because layout needs the router provider as there are components like login and logout button that use navigation hooks.
- queryClient is now a prop that App, instead of moving back to exporting/importing queryClient i found that this was the middle solution as i could not use useQueryClient in loaders since they. are not react components. [Recommended read for this](https://tkdodo.eu/blog/react-query-meets-react-router)
