### PR TITLE
Change name event to agenda

### DIFF
--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -74,7 +74,7 @@ function Header() {
               {user ? (
                 <>
                   <NavButton to="/events" $color="secondary">
-                    Events
+                    AGENDA
                   </NavButton>
                   <NavButton to="/account" $color="secondary">
                     Account


### PR DESCRIPTION
Changed name `EVENTS` to `AGENDA` in the navigation. Note that the user flow will be optimized in a seperate PR: https://github.com/lexicongovernance/pluraltools-frontend/issues/221