### PR TITLE
Events redirect

### DIFF
--- a/packages/api/src/types/CycleType.ts
+++ b/packages/api/src/types/CycleType.ts
@@ -2,7 +2,7 @@ export type GetCycleResponse = {
   id: string;
   createdAt: string;
   updatedAt: string;
-  status: 'OPEN' | 'CLOSED' | 'RESULTS' | null;
+  status: 'OPEN' | 'CLOSED' | 'UPCOMING' | null;
   startAt: string;
   endAt: string;
   forumQuestions: {

--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -69,6 +69,19 @@ async function landingLoader(queryClient: QueryClient) {
   return null;
 }
 
+async function eventsLoader(queryClient: QueryClient) {
+  const events = await queryClient.fetchQuery({
+    queryKey: ['events'],
+    queryFn: fetchEvents,
+  });
+
+  if (events?.length === 1) {
+    return redirect(`/events/${events?.[0].id}`);
+  }
+
+  return null;
+}
+
 const router = (queryClient: QueryClient) =>
   createBrowserRouter([
     {
@@ -93,6 +106,7 @@ const router = (queryClient: QueryClient) =>
               Component: Register,
             },
             {
+              loader: () => eventsLoader(queryClient),
               path: '/events',
               Component: Events,
             },

--- a/packages/berlin/src/pages/Event.tsx
+++ b/packages/berlin/src/pages/Event.tsx
@@ -10,6 +10,7 @@ import { FlexColumn } from '../components/containers/FlexColum.styled';
 import BackButton from '../components/backButton';
 import EventCard from '../components/eventCard';
 import VotingCards from '../components/votingCards';
+import { useMemo } from 'react';
 
 function Event() {
   const { eventId } = useParams();
@@ -18,17 +19,33 @@ function Event() {
     queryFn: () => fetchEvent(eventId || ''),
     enabled: !!eventId,
   });
+
   const { data: eventCycles } = useQuery({
     queryKey: ['events', eventId, 'cycles'],
     queryFn: () => fetchEventCycles(eventId || ''),
     enabled: !!eventId,
   });
 
+  const openCycles = useMemo(
+    () => eventCycles?.filter((cycle) => cycle.status === 'OPEN'),
+    [eventCycles],
+  );
+  const upcomingCycles = useMemo(
+    () => eventCycles?.filter((cycle) => cycle.status === 'UPCOMING'),
+    [eventCycles],
+  );
+  const closedCycles = useMemo(
+    () => eventCycles?.filter((cycle) => cycle.status === 'CLOSED'),
+    [eventCycles],
+  );
+
   return (
     <FlexColumn $gap="2rem">
       <BackButton />
       {event && <EventCard event={event} $direction="row" />}
-      {/* {eventCycles && <VotingCards state="open" cards={eventCycles} />} */}
+      {!!openCycles?.length && <VotingCards state="open" cards={openCycles} />}
+      {!!upcomingCycles?.length && <VotingCards state="upcoming" cards={upcomingCycles} />}
+      {!!closedCycles?.length && <VotingCards state="closed" cards={closedCycles} />}
     </FlexColumn>
   );
 }


### PR DESCRIPTION
## overview
- adds cards sections
- adds redirect on /events page to events/:eventId if only one event exists. so when you press it in the header it can automatically go to the vote page

flow is a bit confusing at this stage but easy to demo

- if you click account in header and submit all registrations you will eventually reach holding page
- if you click agenda you can showcase voting