### PR TITLE
Results card groups dropwdown

### DIFF
--- a/packages/berlin/src/components/iconButton/IconButton.tsx
+++ b/packages/berlin/src/components/iconButton/IconButton.tsx
@@ -10,7 +10,7 @@ type IconButtonProps = {
   disabled?: boolean;
   $padding?: number;
   $flipVertical?: boolean;
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 } & StyledButtonProps;
 
 function IconButton({

--- a/packages/berlin/src/components/resultCard/ResultCard.styled.tsx
+++ b/packages/berlin/src/components/resultCard/ResultCard.styled.tsx
@@ -11,11 +11,6 @@ export const Card = styled.article<{ $expanded: boolean }>`
   transition: height 0.3s ease-in-out;
   width: 100%;
 
-  .arrow {
-    transform: rotate(${(props) => (props.$expanded ? '180deg' : '0deg')});
-    transition: transform 0.3s ease-in-out;
-  }
-
   .statistics {
     display: ${(props) => (props.$expanded ? 'flex' : 'none')};
   }

--- a/packages/berlin/src/components/resultCard/ResultCard.tsx
+++ b/packages/berlin/src/components/resultCard/ResultCard.tsx
@@ -1,5 +1,5 @@
 // React and third-party libraries
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 // Store
 import { useAppStore } from '../../store';
@@ -10,6 +10,7 @@ import { Bold } from '../typography/Bold.styled';
 import { FlexColumn } from '../containers/FlexColum.styled';
 import { FlexRow } from '../containers/FlexRow.styled';
 import { Subtitle } from '../typography/Subtitle.styled';
+import IconButton from '../iconButton';
 
 // Styled Components
 import { Badge, Card } from './ResultCard.styled';
@@ -32,11 +33,21 @@ type ResultCardProps = {
 };
 
 function ResultCard({ $expanded, option, index, onClick }: ResultCardProps) {
+  const [groupsExpanded, setGroupsExpanded] = useState(false);
   const theme = useAppStore((state) => state.theme);
   const formattedPluralityScore = useMemo(() => {
     const score = parseFloat(option.pluralityScore);
     return score % 1 === 0 ? score.toFixed(0) : score.toFixed(3);
   }, [option.pluralityScore]);
+
+  const handleGroupsClick = (
+    e:
+      | React.MouseEvent<HTMLButtonElement, MouseEvent>
+      | React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    e.stopPropagation();
+    setGroupsExpanded(!groupsExpanded);
+  };
 
   return (
     <Card $expanded={$expanded} onClick={onClick}>
@@ -71,11 +82,21 @@ function ResultCard({ $expanded, option, index, onClick }: ResultCardProps) {
               <Bold>Distinct groups:</Bold> {option.distinctGroups}
             </Body>
           </FlexRow>
-          <FlexRow>
-            <Body>
-              <Bold>Group names:</Bold> {option.listOfGroupNames.sort().join(', ')}
-            </Body>
-          </FlexRow>
+          <FlexColumn onClick={(e) => handleGroupsClick(e)} $gap="0.5rem">
+            <FlexRow>
+              <Body>
+                <Bold>Group names:</Bold>
+              </Body>
+              <IconButton
+                $padding={4}
+                $color="secondary"
+                onClick={(e) => handleGroupsClick(e)}
+                icon={{ src: `/icons/arrow-down-${theme}.svg`, alt: '' }}
+                $flipVertical={groupsExpanded}
+              />
+            </FlexRow>
+            <Body>{groupsExpanded && option.listOfGroupNames.sort().join(', ')}</Body>
+          </FlexColumn>
         </FlexColumn>
         <Separator />
         {option.optionSubTitle && <Body>{option.optionSubTitle}</Body>}

--- a/packages/berlin/src/components/resultCard/ResultCard.tsx
+++ b/packages/berlin/src/components/resultCard/ResultCard.tsx
@@ -59,7 +59,12 @@ function ResultCard({ $expanded, option, index, onClick }: ResultCardProps) {
           <FlexRow $gap="0.5rem">
             <Subtitle>{option.optionTitle}</Subtitle>
           </FlexRow>
-          <img className="arrow" src={`/icons/arrow-down-${theme}.svg`} alt="Arrow icon" />
+          <IconButton
+            $padding={0}
+            $color="secondary"
+            icon={{ src: `/icons/arrow-down-${theme}.svg`, alt: '' }}
+            $flipVertical={$expanded}
+          />
         </FlexRow>
         <FlexRow>
           <Body>


### PR DESCRIPTION
## Overview
Adding an arrow to indicate that group names at results card when expanded, can be further expanded to see its names.

## Evidence:
![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/4e1ed58d-4f00-499d-a1cc-5a1876577054)

`Names will be shown as a comma separated string, as we are sorting and joining them with (,). This can be changed if wanted`