### PR TITLE
Update safe area from 720px to 1080px

### DIFF
--- a/packages/berlin/src/layout/Layout.styled.tsx
+++ b/packages/berlin/src/layout/Layout.styled.tsx
@@ -4,5 +4,5 @@ export const Main = styled.main`
   margin-inline: auto;
   min-height: calc(100vh - 17.5rem);
   padding-block: 4rem;
-  width: min(90%, 720px);
+  width: min(90%, 1080px);
 `;


### PR DESCRIPTION
## Closes #266
This PR modifies our safe area from 720px to 1080px, meaning that we now have more horizontal space (more than core) but might look weird.

## Evidence:
Landing:
![landing](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/fbe02d52-cf6b-4ec1-b41b-509780187752)
Account:
![registration](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/8eb76e93-1799-44d0-84c1-7e47747e577c)
Vote:
![cycle](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/3caeb785-f58d-4357-bf04-e3fb75d53205)
Results:
![results](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/6fc074a2-4def-4700-8ec7-27f0c536043e)
