### PR TITLE
Remove name autocomplete

### DIFF
--- a/packages/api/src/updateUserData.ts
+++ b/packages/api/src/updateUserData.ts
@@ -8,7 +8,7 @@ async function updateUserData({
   email,
   groupIds,
   userAttributes,
-}: PutUserRequest): Promise<GetUserResponse | null> {
+}: PutUserRequest): Promise<{ data: GetUserResponse } | { errors: string[] } | null> {
   try {
     const response = await fetch(`${import.meta.env.VITE_SERVER_URL}/api/users/${userId}`, {
       method: 'PUT',
@@ -30,8 +30,8 @@ async function updateUserData({
       throw new Error(`HTTP error! Status: ${response.status}`);
     }
 
-    const user = (await response.json()) as { data: GetUserResponse };
-    return user.data;
+    const user = (await response.json()) as { data: GetUserResponse } | { errors: string[] };
+    return user;
   } catch (error) {
     console.error('Error updating user:', error);
     return null;

--- a/packages/api/src/updateUserData.ts
+++ b/packages/api/src/updateUserData.ts
@@ -27,6 +27,10 @@ async function updateUserData({
     });
 
     if (!response.ok) {
+      if (response.status === 400) {
+        const errors = (await response.json()) as { errors: string[] };
+        return errors;
+      }
       throw new Error(`HTTP error! Status: ${response.status}`);
     }
 

--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -155,15 +155,22 @@ function AccountForm({
   const { mutate: mutateUserData } = useMutation({
     mutationFn: updateUserData,
     onSuccess: async (body) => {
-      if (body) {
-        await queryClient.invalidateQueries({ queryKey: ['user'] });
-        await queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'groups'] });
+      if (!body) {
+        return;
+      }
 
-        toast.success('User data updated!');
+      if ('errors' in body) {
+        toast.error(`There was an error: ${body.errors.join(', ')}`);
+        return;
+      }
 
-        if (events?.length === 1) {
-          navigate(`/events/${events?.[0].id}/register`);
-        }
+      await queryClient.invalidateQueries({ queryKey: ['user'] });
+      await queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'groups'] });
+
+      toast.success('User data updated!');
+
+      if (events?.length === 1) {
+        navigate(`/events/${events?.[0].id}/register`);
       }
     },
     onError: () => {
@@ -277,11 +284,17 @@ function AccountForm({
           <Input
             label="Username"
             placeholder="Enter your Username"
+            autoComplete="off"
             required
             {...register('username', { required: 'Username is required', minLength: 3 })}
             errors={errors.username ? [errors.username.message ?? ''] : []}
           />
-          <Input label="Name" placeholder="(First name, Last name)" {...register('name')} />
+          <Input
+            label="Name"
+            autoComplete="off"
+            placeholder="(First name, Last name)"
+            {...register('name')}
+          />
           <Input label="Email" placeholder="Enter your Email" {...register('email')} />
           <Controller
             name="group"

--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -155,6 +155,7 @@ function AccountForm({
   const { mutate: mutateUserData } = useMutation({
     mutationFn: updateUserData,
     onSuccess: async (body) => {
+      console.log({ body });
       if (!body) {
         return;
       }


### PR DESCRIPTION
closes #281 

## overview
- removed name and username autocomplete
- adds error handling toast to user update in case username/email is duplicated