### PR TITLE
298 selects are not working on safari

### DIFF
--- a/packages/berlin/src/components/select/Select.styled.tsx
+++ b/packages/berlin/src/components/select/Select.styled.tsx
@@ -53,7 +53,7 @@ export const Dropdown = styled.div`
   z-index: 2;
 `;
 
-export const Option = styled.option`
+export const Option = styled.p`
   padding: 0.5rem 1rem;
 
   &:hover {


### PR DESCRIPTION
## Closes: #298

This fixes the Safari issue for dropdown, might not be the SEO way to go but we will explore a better solution when we implement the Radix Components for this

## Evidence:
<img width="478" alt="Screenshot 2024-03-12 at 2 16 26 PM" src="https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/b71628cd-2bb8-432e-9ee3-b9f026e0aac9">
