### PR TITLE
fix telegram handle

### DIFF
--- a/packages/api/src/types/UserType.ts
+++ b/packages/api/src/types/UserType.ts
@@ -16,6 +16,6 @@ export type PutUserRequest = {
   lastName: string;
   email?: string;
   groupIds: string[];
-  telegram?: string;
+  telegram: string | null;
   userAttributes: Record<string, string>;
 };

--- a/packages/api/src/types/UserType.ts
+++ b/packages/api/src/types/UserType.ts
@@ -16,6 +16,6 @@ export type PutUserRequest = {
   lastName: string;
   email?: string;
   groupIds: string[];
-  telegram: string | null;
+  telegram?: string | null;
   userAttributes: Record<string, string>;
 };

--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -59,7 +59,7 @@ type InitialUser = {
   lastName: string;
   email: string;
   group: string;
-  telegram: string;
+  telegram: string | null;
   userAttributes: UserAttributes | undefined;
 };
 
@@ -96,7 +96,7 @@ function Account() {
       firstName: user?.firstName || '',
       lastName: user?.lastName || '',
       email: user?.email || '',
-      telegram: user?.telegram || '',
+      telegram: user?.telegram || null,
       group: (userGroups && userGroups[0]?.id) || '',
       userAttributes: userAttributes?.reduce(
         (acc, curr) => {

--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -244,7 +244,7 @@ function AccountForm({
         email: value.email,
         firstName: value.firstName,
         lastName: value.lastName,
-        telegram: value.telegram,
+        telegram: value.telegram?.trim() !== '' ? value.telegram?.trim() : null,
         groupIds: [value.group],
         userAttributes: {
           ...value.userAttributes,


### PR DESCRIPTION
### The problem 

In the backend we require that the username is unique (which is fine as telegram handles should be unique):

```
export const users = pgTable('users', {
  id: uuid('id').primaryKey().defaultRandom(),
  username: varchar('username', { length: 256 }).unique(),
  firstName: varchar('first_name'),
  lastName: varchar('last_name'),
  email: varchar('email', { length: 256 }).unique(),
  telegram: varchar('telegram', { length: 256 }).unique(),
  createdAt: timestamp('created_at').notNull().defaultNow(),
  updatedAt: timestamp('updated_at').notNull().defaultNow(),
});
```

However, providing the telegram handle is optional and if no telegram handle is provided the frontend currently will insert and empty string instead: `telegram: user?.telegram || " "`

The problem is that once a single user takes the empty string this is not available for any upcomming user anymore as the telegram handle must be unique by definition (emtpy strings are the same). Therefore, a user is unable to submit. 

### Solution 

`telegram: user?.telegram || null`
