### PR TITLE
fix logo image breaking on popup

### DIFF
--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -152,11 +152,11 @@ async function redirectToCycleResultsLoader(
 
 const router = (queryClient: QueryClient) =>
   createBrowserRouter([
+    { path: '/popup', element: <PassportPopupRedirect /> },
     {
       element: <BerlinLayout />,
       children: [
         { path: '/', loader: () => redirectOnLandingLoader(queryClient), element: <Landing /> },
-        { path: '/popup', element: <PassportPopupRedirect /> },
         {
           loader: () => redirectToLandingLoader(queryClient),
           children: [

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -69,7 +69,12 @@ function Header() {
     <SyledHeader>
       <HeaderContainer>
         <LogoContainer onClick={() => navigate('/')}>
-          <LogoImage src={header.logo.src} alt={header.logo.alt} height={96} width={96} />
+          <LogoImage
+            src={window.location.origin + header.logo.src}
+            alt={header.logo.alt}
+            height={96}
+            width={96}
+          />
           <LogoTextContainer>
             <LogoTitle>{header.title}</LogoTitle>
             <LogoSubtitle>{header.subtitle}</LogoSubtitle>

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -69,12 +69,7 @@ function Header() {
     <SyledHeader>
       <HeaderContainer>
         <LogoContainer onClick={() => navigate('/')}>
-          <LogoImage
-            src={window.location.origin + header.logo.src}
-            alt={header.logo.alt}
-            height={96}
-            width={96}
-          />
+          <LogoImage src={header.logo.src} alt={header.logo.alt} height={96} width={96} />
           <LogoTextContainer>
             <LogoTitle>{header.title}</LogoTitle>
             <LogoSubtitle>{header.subtitle}</LogoSubtitle>


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-frontend/issues/296

## overview
inspired by https://stackoverflow.com/questions/18723199/popup-window-has-a-broken-image-link

### explanation
when opening the /popup link the header would be rendered and the /logos/logo.png request would fail and that failure would get stored in local cache for the user. So decided to move /popup outside of the layout element, it shows a black screen but then again it will not query anything on the site and therefore not break any caches for the user