### PR TITLE
367 create separate page for data policy

### DIFF
--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -203,13 +203,13 @@ const router = (queryClient: QueryClient) =>
                       path: ':cycleId/results',
                       Component: Results,
                     },
+                    {
+                      path: ':cycleId/options/:optionId',
+                      Component: Option,
+                    },
                   ],
                 },
               ],
-            },
-            {
-              path: '/events/:eventId/cycles/:cycleId/options/:optionId',
-              Component: Option,
             },
           ],
         },

--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -12,15 +12,16 @@ import { fetchEvents, fetchUserData, fetchCycle, fetchRegistration } from 'api';
 import { default as BerlinLayout } from './layout/index.ts';
 import Account from './pages/Account';
 import Cycle from './pages/Cycle.tsx';
+import DataPolicy from './pages/DataPolicy.tsx';
 import Event from './pages/Event.tsx';
 import Events from './pages/Events.tsx';
 import Holding from './pages/Holding';
 import Landing from './pages/Landing';
 import Onboarding from './pages/Onboarding';
+import Option from './pages/Option.tsx';
 import PassportPopupRedirect from './pages/Popup';
 import Register from './pages/Register';
 import Results from './pages/Results.tsx';
-import Option from './pages/Option.tsx';
 
 /**
  * Redirects the user to the landing page if they are not logged in
@@ -161,6 +162,7 @@ const router = (queryClient: QueryClient) =>
           loader: () => redirectToLandingLoader(queryClient),
           children: [
             { path: '/onboarding', Component: Onboarding },
+            { path: '/data-policy', Component: DataPolicy },
             {
               path: '/account',
               Component: Account,

--- a/packages/berlin/src/data/dataPolicy.ts
+++ b/packages/berlin/src/data/dataPolicy.ts
@@ -1,0 +1,198 @@
+const dataPolicy = {
+  title: 'Data Privacy Notice',
+  content: [
+    {
+      id: 0,
+      subtitle: 'Lexicon Governance',
+      copy: [
+        {
+          id: 0,
+          text: 'Lexicon Governance (“Lexicon”) is a Limited Liability Company incorporated under the laws of the United Kingdom. Its mission is to benefit the community of open-source researchers, academics, and technologists engaged in provisioning research public goods through collective intelligence.',
+        },
+        {
+          id: 1,
+          text: 'This document aims to inform you about how Lexicon uses your personal data in connection with the Plural Research Experiment and in compliance with the EU General Data Protection Regulation (the "Data Protection Legislation") for EU data subjects. Under the Data Protection Legislation, you have rights, and Lexicon has obligations, with respect to your personal data. The purpose of this notice is to explain how and why Lexicon, and persons engaged by Lexicon, will use, store, and otherwise process your personal data. This notice also sets out your rights under the Data Protection Legislation, and how you may exercise them. For individuals in California, please see the California notices below.',
+        },
+        {
+          id: 2,
+          text: 'Lexicon commits to responsibly stewarding data in accordance with the attached data policy, ensuring privacy and integrity, and transparent management of the data associated with this initiative.',
+        },
+      ],
+    },
+    {
+      id: 1,
+      subtitle: 'Your Personal Data',
+      copy: [
+        {
+          id: 0,
+          text: 'Lexicon operates the Plural Research Experiment website at www.pluralresearch.org and collects information through its integration with Zupass for participant authentication and management. This policy is relevant to you if you are a participant in the Plural Research Experiment or otherwise provide personal data related to your participation.',
+        },
+        {
+          id: 1,
+          text: 'Your engagement with the Plural Research Experiment, including your registration, interaction with Lexicon and Zupass, and any direct communications, may involve providing your personal data. This may include device information, name, affiliation, research submissions, credentials, voting preferences, email address, contact details, and other related information.',
+        },
+      ],
+    },
+    {
+      id: 2,
+      subtitle: 'Purpose of Data Collection: How Lexicon May Use Your Personal Data',
+      copy: [
+        {
+          id: 0,
+          text: 'The collection of data is essential for the effective administration of plural mechanisms and the enhancement of the event experience. Lexicon, may use your personal data for purposes including:',
+        },
+        {
+          id: 1,
+          type: 'LIST',
+          items: [
+            {
+              id: 0,
+              text: 'Administering and managing the Plural Research Experiment, including participant authentication to prevent impersonation and enhance event experiences.',
+            },
+            {
+              id: 1,
+              text: 'Resolving technical issues.',
+            },
+            {
+              id: 2,
+              text: 'Accurately calculating plurality and peer-prediction scores for collective decision-making in grant allocation.',
+            },
+            {
+              id: 3,
+              text: 'Processing participant information for the collective decision-making process.',
+            },
+            {
+              id: 4,
+              text: 'Ensuring the integrity and accuracy of votes and preferences expressed in the experiment.',
+            },
+            {
+              id: 5,
+              text: 'Communicating with you regarding updates, opportunities, or issues related to the Plural Research Experiment.',
+            },
+            {
+              id: 6,
+              text: 'Compliance with legal or regulatory obligations.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 3,
+      subtitle: 'Sharing Your Personal Data & Basis for Processing',
+      copy: [
+        {
+          id: 0,
+          text: 'Your personal data may be processed by Lexicon or one of its contractors who are committed to maintaining the confidentiality of your data.',
+        },
+        {
+          id: 1,
+          text: 'The processing of your personal data by Lexicon is based on the following legal grounds as defined by the GDPR: (a) Consent: where you have explicitly agreed to our processing of your personal data for specific purposes; (b) Necessity: where the processing is necessary to engage in the Plural Research Experiment; (c) Legal Obligation: where we need to process your data to comply with our legal obligations; (d) Legitimate Interests: We may process your data when it is in our legitimate interests to do so, and these interests are not overridden by your data protection rights. This includes data processing that is necessary to improve and ensure the security of our experiment, provided it respects your rights and freedoms.',
+        },
+      ],
+    },
+    {
+      id: 4,
+      subtitle: 'Data Usage Beyond Grant and Events Administration',
+      copy: [
+        {
+          id: 0,
+          text: 'If Lexicon considers utilizing the collected data for purposes beyond the current scope of administering the Plural Research Experiment, such action will necessitate the unanimous and explicit consent of an Oversight Committee (a group of 3 independent members). This requirement is in place to guarantee that any extended use of the data is consistent with collective interests and adheres to ethical standards.',
+        },
+      ],
+    },
+    {
+      id: 5,
+      subtitle: 'Retention and Deletion of Your Personal Data',
+      copy: [
+        {
+          id: 0,
+          text: 'Lexicon will retain your personal data as long as necessary for the administration of the Plural Research Experiment. After this, your data will be securely deleted. In the future, Lexicon aims to conduct activities without personal data, relying instead on zero-knowledge processes. In the unlikely event of a personal data breach, Lexicon will promptly notify the appropriate parties within 72 hours.',
+        },
+      ],
+    },
+    {
+      id: 6,
+      subtitle: 'Changes to This Policy',
+      copy: [
+        {
+          id: 0,
+          text: 'Lexicon may make material changes to this Privacy Policy from time to time with the unanimous consent of the Oversight Committee. Lexicon will notify users of any material changes through a notice on our platform. By continuing to access or use the Services after those changes become effective, you agree to be bound by the revised Privacy Policy.',
+        },
+      ],
+    },
+    {
+      id: 7,
+      subtitle: 'Your Rights',
+      copy: [
+        {
+          id: 0,
+          text: 'You have certain data protection rights, including the right to:',
+        },
+        {
+          id: 1,
+          type: 'LIST',
+          items: [
+            {
+              id: 0,
+              text: 'be informed about the purposes for which your personal data are processed;',
+            },
+            {
+              id: 1,
+              text: 'access your personal data;',
+            },
+            {
+              id: 2,
+              text: 'stop direct marketing;',
+            },
+            {
+              id: 3,
+              text: 'restrict the processing of your personal data;',
+            },
+            {
+              id: 4,
+              text: 'have incomplete or inaccurate personal data corrected;',
+            },
+            {
+              id: 5,
+              text: 'ask us to stop processing your personal data; be informed of a personal data breach (unless the breach is unlikely to be prejudicial to you);',
+            },
+            {
+              id: 6,
+              text: 'complain to the Data Protection Ombudsman; and',
+            },
+            {
+              id: 7,
+              text: 'require us to delete your personal data in some limited circumstances.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 8,
+      subtitle: 'California Provisions (aka “Dinesh Clause”)',
+      copy: [
+        {
+          id: 0,
+          text: 'Lexicon does not knowingly collect information online from children under 13. If you are a parent or guardian and you learn that your children have provided Lexicon with Personal Information, please contact us. If Lexicon becomes aware that Personal Information has been collected from a child under age 13 without verification of parental consent, it will take steps to remove that information from our servers.',
+        },
+        {
+          id: 1,
+          text: 'Keep in mind Lexicon does not use personal information for marketing, whether by ourselves or by others. Lexicon does not share information with third parties for direct marketing purposes. To request a copy of the information disclosure pursuant to Section 1798.83 of the California Civil Code, please contact us.',
+        },
+      ],
+    },
+    {
+      id: 9,
+      subtitle: 'Contact Us',
+      copy: [
+        {
+          id: 0,
+          text: 'If you have questions or concerns about this notice or your personal data, please contact us at legal@lexicongovernance.org, marking your communication "Data Protection Enquiry."',
+        },
+      ],
+    },
+  ],
+};
+export default dataPolicy;

--- a/packages/berlin/src/pages/DataPolicy.tsx
+++ b/packages/berlin/src/pages/DataPolicy.tsx
@@ -1,0 +1,39 @@
+// Components
+import { Body } from '../components/typography/Body.styled';
+import { FlexColumn } from '../components/containers/FlexColum.styled';
+import { SafeArea } from '../layout/Layout.styled';
+import { Subtitle } from '../components/typography/Subtitle.styled';
+import { Title } from '../components/typography/Title.styled';
+
+// Data
+import dataPolicy from '../data/dataPolicy';
+
+function DataPolicy() {
+  return (
+    <SafeArea>
+      <FlexColumn $gap="1.5rem">
+        <Title>{dataPolicy.title}</Title>
+        {dataPolicy.content.map((section) => (
+          <FlexColumn key={section.id}>
+            <Subtitle>{section.subtitle}</Subtitle>
+            {section.copy.map((copy) => {
+              if (copy.type === 'LIST') {
+                return (
+                  <ul key={copy.id} style={{ paddingInlineStart: '2.5rem' }}>
+                    {copy.items.map((item) => (
+                      <li key={item.id}>
+                        <Body>{item.text}</Body>
+                      </li>
+                    ))}
+                  </ul>
+                );
+              } else return <Body key={copy.id}>{copy.text}</Body>;
+            })}
+          </FlexColumn>
+        ))}
+      </FlexColumn>
+    </SafeArea>
+  );
+}
+
+export default DataPolicy;


### PR DESCRIPTION
## Closes: #367

You can access the page at `/data-policy`

## Evidence:
![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/686b506d-f5fe-4747-8fef-6aa8c1f8b99d)
