### PR TITLE
401 hide back arrow from cycles page

### DIFF
--- a/packages/berlin/src/pages/Event.tsx
+++ b/packages/berlin/src/pages/Event.tsx
@@ -51,7 +51,7 @@ function Event() {
 
   return (
     <FlexColumn $gap="2rem">
-      <BackButton />
+      {/* <BackButton /> */}
       {!!openCycles?.length && <CycleTable cycles={openCycles} status="open" />}
       {!!closedCycles?.length && <CycleTable cycles={closedCycles} status="closed" />}
       {event && <EventCard event={event} $direction="row" />}

--- a/packages/berlin/src/pages/Event.tsx
+++ b/packages/berlin/src/pages/Event.tsx
@@ -10,7 +10,7 @@ import { GetCycleResponse, fetchEvent, fetchEventCycles } from 'api';
 import { Body } from '../components/typography/Body.styled';
 import { FlexColumn } from '../components/containers/FlexColum.styled';
 import { Table } from '../components/table';
-import BackButton from '../components/back-button';
+// import BackButton from '../components/back-button';
 import Button from '../components/button';
 import EventCard from '../components/event-card';
 import Link from '../components/link';


### PR DESCRIPTION
## Closes: #401

## Evidence:
![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/c27060b8-b12d-4b3c-9de1-393a326a4fea)