### PR TITLE
Save registration field option value

### DIFF
--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -649,7 +649,7 @@ function SelectInput(props: {
             label={props.name}
             placeholder="Choose a value"
             required={!!props.required}
-            options={props.options.map((option) => ({ id: option.id, name: option.value }))}
+            options={props.options.map((option) => ({ id: option.value, name: option.value }))}
             errors={props.errors[props.id] ? [props.errors[props.id]?.message ?? ''] : []}
             onBlur={field.onBlur}
             onChange={(val) => field.onChange(val)}


### PR DESCRIPTION
closes #426 

the id for the registration field is now the actual value on the registration page.

this will cause ui issues on production for existing registrations where the id was stored, an admin pr is needed to help with this issue