### PR TITLE
invalidate cache for groups when joining

### DIFF
--- a/packages/berlin/src/components/tables/groups-table/GroupsTable.tsx
+++ b/packages/berlin/src/components/tables/groups-table/GroupsTable.tsx
@@ -93,7 +93,7 @@ function GroupsTable({ groupCategoryName }: { groupCategoryName?: string | null 
   const theme = useAppStore((state) => state.theme);
 
   const { data: usersToGroups } = useQuery({
-    queryKey: ['user', user?.id, 'groups'],
+    queryKey: ['user', user?.id, 'users-to-groups'],
     queryFn: () => fetchUsersToGroups(user?.id || ''),
     enabled: !!user?.id,
   });
@@ -102,7 +102,7 @@ function GroupsTable({ groupCategoryName }: { groupCategoryName?: string | null 
     mutationFn: deleteUsersToGroups,
     onSuccess: (body) => {
       if (body) {
-        queryClient.invalidateQueries({ queryKey: ['users-to-groups', user?.id] });
+        queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'users-to-groups'] });
       }
     },
   });

--- a/packages/berlin/src/pages/PublicGroupRegistration.tsx
+++ b/packages/berlin/src/pages/PublicGroupRegistration.tsx
@@ -50,7 +50,7 @@ function PublicGroupRegistration() {
   });
 
   const { data: usersToGroups } = useQuery({
-    queryKey: ['user', user?.id, 'groups'],
+    queryKey: ['user', user?.id, 'users-to-groups'],
     queryFn: () => fetchUsersToGroups(user?.id || ''),
     enabled: !!user?.id,
   });

--- a/packages/berlin/src/pages/SecretGroupRegistration.tsx
+++ b/packages/berlin/src/pages/SecretGroupRegistration.tsx
@@ -64,7 +64,7 @@ function SecretGroupRegistration() {
     mutationFn: postGroup,
     onSuccess: (body) => {
       if (body) {
-        queryClient.invalidateQueries({ queryKey: ['users-to-groups', user?.id] });
+        queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'users-to-groups'] });
         toast.success(`Group ${groupName} created succesfully!`);
         toast.success(`Joined group ${groupName} succesfully!`);
         setIsDialogOpen(false);
@@ -83,7 +83,7 @@ function SecretGroupRegistration() {
       if (!body) {
         return;
       }
-      queryClient.invalidateQueries({ queryKey: ['user', 'groups'] });
+      queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'users-to-groups'] });
       toast.success(`Joined ${groupName} group succesfully!`);
     },
     onError: () => {


### PR DESCRIPTION
## overview
when joining a group or creating a group, the `your groups` table is invalidated and it should seem like the table is updated straight away