### PR TITLE
Improve join group error

### DIFF
--- a/packages/api/src/deleteUsersToGroups.ts
+++ b/packages/api/src/deleteUsersToGroups.ts
@@ -2,7 +2,7 @@ import { DeleteUsersToGroupsRequest, DeleteUsersToGroupsResponse } from './types
 
 async function deleteUsersToGroups({
   userToGroupId,
-}: DeleteUsersToGroupsRequest): Promise<DeleteUsersToGroupsResponse | null> {
+}: DeleteUsersToGroupsRequest): Promise<DeleteUsersToGroupsResponse | { errors: string[] } | null> {
   try {
     const response = await fetch(
       `${import.meta.env.VITE_SERVER_URL}/api/users-to-groups/${userToGroupId}`,
@@ -16,7 +16,11 @@ async function deleteUsersToGroups({
     );
 
     if (!response.ok) {
-      throw new Error(`HTTP Error! Status: ${response.status}`);
+      if (response.status < 500) {
+        const errors = (await response.json()) as { errors: string[] };
+        return errors;
+      }
+      throw new Error(`HTTP error! Status: ${response.status}`);
     }
 
     const group = (await response.json()) as { data: DeleteUsersToGroupsResponse };

--- a/packages/api/src/postUsersToGroups.ts
+++ b/packages/api/src/postUsersToGroups.ts
@@ -3,7 +3,7 @@ import { PostUsersToGroupsRequest, PostUsersToGroupsResponse } from './types';
 async function postUserToGroups({
   secret,
   groupId,
-}: PostUsersToGroupsRequest): Promise<PostUsersToGroupsResponse | null> {
+}: PostUsersToGroupsRequest): Promise<PostUsersToGroupsResponse | { errors: string[] } | null> {
   try {
     const response = await fetch(`${import.meta.env.VITE_SERVER_URL}/api/users-to-groups`, {
       method: 'POST',
@@ -15,7 +15,11 @@ async function postUserToGroups({
     });
 
     if (!response.ok) {
-      throw new Error(`HTTP Error! Status: ${response.status}`);
+      if (response.status < 500) {
+        const errors = (await response.json()) as { errors: string[] };
+        return errors;
+      }
+      throw new Error(`HTTP error! Status: ${response.status}`);
     }
 
     const group = (await response.json()) as { data: PostUsersToGroupsResponse };

--- a/packages/api/src/putUsersToGroups.ts
+++ b/packages/api/src/putUsersToGroups.ts
@@ -3,7 +3,7 @@ import { PostUsersToGroupsResponse, PutUsersToGroupsRequest } from './types';
 async function postUsersToGroups({
   groupId,
   userToGroupId,
-}: PutUsersToGroupsRequest): Promise<PostUsersToGroupsResponse | null> {
+}: PutUsersToGroupsRequest): Promise<PostUsersToGroupsResponse | { errors: string[] } | null> {
   try {
     const response = await fetch(
       `${import.meta.env.VITE_SERVER_URL}/api/users-to-groups/${userToGroupId}`,
@@ -18,7 +18,11 @@ async function postUsersToGroups({
     );
 
     if (!response.ok) {
-      throw new Error(`HTTP Error! Status: ${response.status}`);
+      if (response.status < 500) {
+        const errors = (await response.json()) as { errors: string[] };
+        return errors;
+      }
+      throw new Error(`HTTP error! Status: ${response.status}`);
     }
 
     const group = (await response.json()) as { data: PostUsersToGroupsResponse };

--- a/packages/berlin/src/components/tables/groups-table/GroupsTable.tsx
+++ b/packages/berlin/src/components/tables/groups-table/GroupsTable.tsx
@@ -102,6 +102,11 @@ function GroupsTable({ groupCategoryName }: { groupCategoryName?: string | null 
     mutationFn: deleteUsersToGroups,
     onSuccess: (body) => {
       if (body) {
+        if ('errors' in body) {
+          toast.error(body.errors[0]);
+          return;
+        }
+
         queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'users-to-groups'] });
       }
     },

--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -167,7 +167,6 @@ function AccountForm({
   const { mutate: mutateUserData } = useMutation({
     mutationFn: putUser,
     onSuccess: async (body) => {
-      console.log({ body });
       if (!body) {
         return;
       }
@@ -188,6 +187,38 @@ function AccountForm({
     },
     onError: () => {
       toast.error('There was an error, please try again.');
+    },
+  });
+
+  const { mutate: mutatePostUsersToGroups } = useMutation({
+    mutationFn: postUsersToGroups,
+    onSuccess: async (body) => {
+      if (!body) {
+        return;
+      }
+
+      if ('errors' in body) {
+        toast.error(`There was an error: ${body.errors.join(', ')}`);
+        return;
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'users-to-groups'] });
+    },
+  });
+
+  const { mutate: mutatePutUsersToGroups } = useMutation({
+    mutationFn: putUsersToGroups,
+    onSuccess: async (body) => {
+      if (!body) {
+        return;
+      }
+
+      if ('errors' in body) {
+        toast.error(`There was an error: ${body.errors.join(', ')}`);
+        return;
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'users-to-groups'] });
     },
   });
 
@@ -260,11 +291,11 @@ function AccountForm({
 
       // Create user to group if it doesn't exist
       if (!value.userToGroupId) {
-        await postUsersToGroups({
+        await mutatePostUsersToGroups({
           groupId: value.groupId,
         });
       } else {
-        await putUsersToGroups({
+        await mutatePutUsersToGroups({
           groupId: value.groupId,
           userToGroupId: value.userToGroupId,
         });

--- a/packages/berlin/src/pages/PublicGroupRegistration.tsx
+++ b/packages/berlin/src/pages/PublicGroupRegistration.tsx
@@ -97,6 +97,12 @@ function PublicGroupRegistration() {
       if (!body) {
         return;
       }
+
+      if ('errors' in body) {
+        toast.error(body.errors.join(', '));
+        return;
+      }
+
       queryClient.invalidateQueries({ queryKey: ['user', user?.id, 'groups'] });
       toast.success(`Updated ${groupCategoryNameParam} group successfully!`);
     },

--- a/packages/berlin/src/pages/SecretGroupRegistration.tsx
+++ b/packages/berlin/src/pages/SecretGroupRegistration.tsx
@@ -83,6 +83,11 @@ function SecretGroupRegistration() {
       if (!body) {
         return;
       }
+      if ('errors' in body) {
+        toast.error(body.errors[0]);
+        return;
+      }
+
       queryClient.invalidateQueries({ queryKey: ['user', 'groups'] });
       toast.success(`Joined ${groupName} group succesfully!`);
     },


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-frontend/issues/470

depends on https://github.com/lexicongovernance/pluraltools-frontend/pull/485
depends on https://github.com/lexicongovernance/pluraltools-backend/pull/387

## overview
handles when the api returns {errors: string[]} instead of {body: string} for joining group and creating a group

![CleanShot 2024-05-16 at 14 24 57@2x](https://github.com/lexicongovernance/pluraltools-frontend/assets/22416585/3080a8eb-ee94-4a38-90c6-b6bd1544b35e)

![CleanShot 2024-05-16 at 14 32 04@2x](https://github.com/lexicongovernance/pluraltools-frontend/assets/22416585/e175d695-e52b-4ffa-815a-20454ca71610)

