### PR TITLE
517 protect results page

### DIFF
--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -153,6 +153,22 @@ async function redirectToCycleResultsLoader(
   return null;
 }
 
+/**
+ * Redirects the user to the cycle page if the cycle is open
+ */
+async function redirectToCycleIfOpen(queryClient: QueryClient, eventId?: string, cycleId?: string) {
+  const cycle = await queryClient.fetchQuery({
+    queryKey: ['cycles', cycleId],
+    queryFn: () => fetchCycle(cycleId || ''),
+  });
+
+  if (cycle?.status === 'OPEN') {
+    return redirect(`/events/${eventId}/cycles/${cycleId}`);
+  }
+
+  return null;
+}
+
 const router = (queryClient: QueryClient) =>
   createBrowserRouter([
     { path: '/popup', element: <PassportPopupRedirect /> },
@@ -211,6 +227,8 @@ const router = (queryClient: QueryClient) =>
                     },
                     {
                       path: ':cycleId/results',
+                      loader: ({ params }) =>
+                        redirectToCycleIfOpen(queryClient, params.eventId, params.cycleId),
                       Component: Results,
                     },
                     {

--- a/packages/berlin/src/components/back-button/BackButton.tsx
+++ b/packages/berlin/src/components/back-button/BackButton.tsx
@@ -2,14 +2,27 @@ import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../../store';
 import IconButton from '../icon-button';
 
-function BackButton() {
+type BackButtonProps = {
+  fallbackRoute?: string;
+};
+
+function BackButton({ fallbackRoute }: BackButtonProps) {
   const navigate = useNavigate();
   const theme = useAppStore((state) => state.theme);
+
+  const handleBackClick = () => {
+    if (fallbackRoute) {
+      navigate(fallbackRoute);
+    } else {
+      navigate(-1);
+    }
+  };
+
   return (
     <IconButton
-      onClick={() => navigate(-1)}
+      onClick={handleBackClick}
       $color="secondary"
-      icon={{ src: `/icons/arrow-back-${theme}.svg`, alt: 'Trash icon' }}
+      icon={{ src: `/icons/arrow-back-${theme}.svg`, alt: 'Back icon' }}
       $padding={0}
     />
   );

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -41,7 +41,7 @@ function Cycle() {
   const queryClient = useQueryClient();
 
   const { user } = useUser();
-  const { cycleId } = useParams();
+  const { eventId, cycleId } = useParams();
   const { data: cycle } = useQuery({
     queryKey: ['cycles', cycleId],
     queryFn: () => fetchCycle(cycleId || ''),
@@ -268,7 +268,7 @@ function Cycle() {
   return (
     <FlexColumn $gap="2rem">
       <FlexColumn>
-        <BackButton />
+        <BackButton fallbackRoute={`/events/${eventId}/cycles`} />
         <Title>{currentCycle?.questionTitle}</Title>
         <Body>{voteInfo}</Body>
         <Body>


### PR DESCRIPTION
## Closes: #517

Fixed if an user tried to navigate to /results from cycle page, but this created an issue with our back arrow (it navigated to -1, which now was the path with /results)

The solution was to add an optional prop to back button so you can determine where to navigate, we might need to update our back arrow in other places, this can be tested.