### PR TITLE
fix group select showing wrong value

### DIFF
--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -332,7 +332,7 @@ const SelectRegistrationDropdown = ({
               registrationFields,
               mode: form.mode,
               index: idx + 1,
-              groupName: form.group?.name || 'None',
+              groupName: form.group?.name || 'Solo',
             }),
           }))}
           placeholder="Select a Proposal"
@@ -386,7 +386,8 @@ function RegisterForm(props: {
 }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [selectedGroupId, setSelectedGroupId] = useState<string>(props.groupId ?? 'none');
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('');
+  const prevSelectGroupId = props.groupId ?? 'none';
 
   const {
     register,
@@ -543,7 +544,7 @@ function RegisterForm(props: {
     <FlexColumn>
       <RegisterGroupSelect
         usersToGroups={props.usersToGroups}
-        selectedGroupId={selectedGroupId}
+        selectedGroupId={selectedGroupId || prevSelectGroupId}
         onChange={setSelectedGroupId}
       />
       <Subtitle>{props.event?.registrationDescription}</Subtitle>


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-frontend/issues/529
closes https://github.com/lexicongovernance/pluraltools-frontend/issues/527

## overview
https://react.dev/learn/you-might-not-need-an-effect

very good read and recently updated.

tdlr for us:
- when we want a component to update because of a new prop we can implement the id in the key prop, that way it will rebuild everything
- have the value calculated on render time without a useState (<- option that i used)