### PR TITLE
fix initial registration

### DIFF
--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -389,6 +389,10 @@ function RegisterForm(props: {
   const [selectedGroupId, setSelectedGroupId] = useState<string>('');
   const prevSelectGroupId = props.groupId ?? 'none';
 
+  // i want to differentiate between when a group is selected and it is not
+  // so i can show the correct registration fields
+  // i will use the selectedGroupId to do this
+
   const {
     register,
     formState: { errors, isSubmitting },
@@ -409,16 +413,16 @@ function RegisterForm(props: {
   }, [props.registrationData, reset]);
 
   const sortedRegistrationFields = useMemo(() => {
-    const sortedFields = filterRegistrationFields(
-      props.registrationFields || [],
-      selectedGroupId === 'none' ? 'user' : 'group',
-    );
+    const regGroupId = selectedGroupId || prevSelectGroupId;
+    const client = regGroupId === 'none' ? 'user' : 'group';
+
+    const sortedFields = filterRegistrationFields(props.registrationFields || [], client);
 
     // Sort by field_display_rank in ascending order
     sortedFields?.sort((a, b) => (a.fieldDisplayRank || 0) - (b.fieldDisplayRank || 0));
 
     return sortedFields;
-  }, [props.registrationFields, selectedGroupId]);
+  }, [props.registrationFields, selectedGroupId, prevSelectGroupId]);
 
   const redirectToHoldingPage = (isApproved: boolean) => {
     if (!isApproved) {
@@ -476,12 +480,15 @@ function RegisterForm(props: {
   });
 
   const onSubmit = (values: Record<string, string>) => {
+    const regGroupId = selectedGroupId || prevSelectGroupId;
+    const client = regGroupId === 'none' ? 'user' : 'group';
+
     if (props.mode === 'edit') {
       updateRegistrationData({
         registrationId: props.registrationId || '',
         body: {
           eventId: props.event?.id || '',
-          groupId: selectedGroupId === 'none' ? null : selectedGroupId,
+          groupId: client === 'user' ? null : regGroupId,
           status: 'DRAFT',
           registrationData: Object.entries(values).map(([key, value]) => ({
             registrationFieldId: key,
@@ -493,7 +500,7 @@ function RegisterForm(props: {
       mutateRegistrationData({
         body: {
           eventId: props.event?.id || '',
-          groupId: selectedGroupId === 'none' ? null : selectedGroupId,
+          groupId: client === 'user' ? null : regGroupId,
           status: 'DRAFT',
           registrationData: Object.entries(values).map(([key, value]) => ({
             registrationFieldId: key,


### PR DESCRIPTION
## overview
a bit of a tricky part of the registration form is that it requires the groupId to be equal to `none` when sending a solo registration. Not because of the server but because all options on a select require a unique key and the unique key for no group is `none`. This means that when the groupId string is equal to none we should send `null`. This was not taking into account that we have to state variables to know the groupId the user wants.

we have 2 groupIds for state: `prev` and `selected` they have a different suffix but the meaning behind them is that the previous one is the one that the user gets from the server and the selected state is for a local interaction the user has made without saving to the server. this causes the following states to pop up:

1. the user has not selected anything so we should only care about the previous state
2. the user has selected something

so we merge these two by doing: regGroupId = selected || prev