### PR TITLE
Fix funding display in results

### DIFF
--- a/packages/berlin/src/components/tables/results-table/ResultsTable.tsx
+++ b/packages/berlin/src/components/tables/results-table/ResultsTable.tsx
@@ -47,7 +47,7 @@ function ResultsTable({ $expanded, option, onClick }: ResultsTableProps) {
   return (
     <Card
       $expanded={$expanded}
-      $showFunding={!!option.allocatedFunding}
+      $showFunding={option.allocatedFunding !== null}
       onClick={onClick}
       $rowgap="2rem"
     >

--- a/packages/berlin/src/pages/Results.tsx
+++ b/packages/berlin/src/pages/Results.tsx
@@ -63,7 +63,8 @@ function Results() {
     .map(([id, stats]) => ({
       id,
       ...stats,
-      allocatedFunding: funding?.allocated_funding[id] || null,
+      allocatedFunding:
+        funding?.allocated_funding[id] !== undefined ? funding.allocated_funding[id] : null,
     }))
     .sort((a, b) => parseFloat(b.pluralityScore) - parseFloat(a.pluralityScore));
 

--- a/packages/berlin/src/pages/Results.tsx
+++ b/packages/berlin/src/pages/Results.tsx
@@ -63,7 +63,7 @@ function Results() {
     .map(([id, stats]) => ({
       id,
       ...stats,
-      allocatedFunding: funding?.allocated_funding[id] || null,
+      allocatedFunding: funding?.allocated_funding[id] !== undefined ? funding.allocated_funding[id] : null,
     }))
     .sort((a, b) => parseFloat(b.pluralityScore) - parseFloat(a.pluralityScore));
 

--- a/packages/berlin/src/pages/Results.tsx
+++ b/packages/berlin/src/pages/Results.tsx
@@ -63,7 +63,7 @@ function Results() {
     .map(([id, stats]) => ({
       id,
       ...stats,
-      allocatedFunding: funding?.allocated_funding[id] !== undefined ? funding.allocated_funding[id] : null,
+      allocatedFunding: funding?.allocated_funding[id] || null,
     }))
     .sort((a, b) => parseFloat(b.pluralityScore) - parseFloat(a.pluralityScore));
 


### PR DESCRIPTION
1) changed `!!option.allocatedFunding` to `option.allocatedFunding !== null` as the later will evaluate true if `option.allocatedFunding` is any value other than `null` including `0`
2) fixed the filter to ensure that 0 values are not filtered out: `allocatedFunding: funding?.allocated_funding[id] !== undefined ? funding.allocated_funding[id] : null`