### PR TITLE
fix empty string not throwing error on number field

### DIFF
--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -867,10 +867,14 @@ function NumberInput(props: {
               return true;
             }
 
+            if (value.trim() === '') {
+              return 'Value is required';
+            }
+
             const v = z.coerce
               .number()
               .int('Value has to be an integer')
-              .min(0, 'Value must be positive')
+              .nonnegative('Value must be positive')
               .safeParse(value);
 
             if (v.success) {


### PR DESCRIPTION
## overview
turns out zod automatically parses and empty string as 0. this gives us a manual check on empty strings

reference: https://github.com/colinhacks/zod/issues/2461