### PR TITLE
561 redirect to results when cycle closes

### DIFF
--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -182,13 +182,13 @@ function Header() {
                             )
                           );
                         })}
-                      <NavButton to={`/events/${events?.[0].id}/cycles`} $color="secondary">
-                        Agenda
-                      </NavButton>
                     </>
                   )}
                   <NavButton to={`/events/${events?.[0].id}/register`} $color="secondary">
                     My proposals
+                  </NavButton>
+                  <NavButton to={`/events/${events?.[0].id}/cycles`} $color="secondary">
+                    Agenda
                   </NavButton>
                   <NavButton to="/account" $color="secondary">
                     Account

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -76,7 +76,7 @@ function Cycle() {
 
   useEffect(() => {
     if (cycle?.status === 'CLOSED') {
-      toast('Cycle has closed. Redirecting to the results page.', {
+      toast('Agenda has closed. Redirecting to results.', {
         icon: '⌛️',
       });
       navigate(`/events/${eventId}/cycles/${cycleId}/results`);

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -76,9 +76,7 @@ function Cycle() {
 
   useEffect(() => {
     if (cycle?.status === 'CLOSED') {
-      toast('Agenda has closed. Redirecting to results.', {
-        icon: '⌛️',
-      });
+      toast('Agenda has closed. Redirecting to results.');
       navigate(`/events/${eventId}/cycles/${cycleId}/results`);
     }
   }, [cycle?.status]);

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -46,6 +46,7 @@ function Cycle() {
     queryKey: ['cycles', cycleId],
     queryFn: () => fetchCycle(cycleId || ''),
     enabled: !!cycleId,
+    refetchInterval: 5000, // Poll every 5 seconds
   });
 
   const { data: userVotes } = useQuery({

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -1,7 +1,7 @@
 // React and third-party libraries
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { redirect, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 
 // API
@@ -40,6 +40,7 @@ type QuestionOption = GetCycleResponse['forumQuestions'][number]['questionOption
 
 function Cycle() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const { user } = useUser();
   const { eventId, cycleId } = useParams();
   const { data: cycle } = useQuery({
@@ -75,7 +76,7 @@ function Cycle() {
 
   useEffect(() => {
     if (cycle?.status === 'CLOSED') {
-      redirect(`/events/${eventId}/cycles/${cycleId}/results`);
+      navigate(`/events/${eventId}/cycles/${cycleId}/results`);
     }
   }, [cycle?.status]);
 

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -1,7 +1,7 @@
 // React and third-party libraries
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
+import { redirect, useParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 
 // API
@@ -40,7 +40,6 @@ type QuestionOption = GetCycleResponse['forumQuestions'][number]['questionOption
 
 function Cycle() {
   const queryClient = useQueryClient();
-
   const { user } = useUser();
   const { eventId, cycleId } = useParams();
   const { data: cycle } = useQuery({
@@ -48,6 +47,7 @@ function Cycle() {
     queryFn: () => fetchCycle(cycleId || ''),
     enabled: !!cycleId,
   });
+
   const { data: userVotes } = useQuery({
     queryKey: ['votes', cycleId],
     queryFn: () => fetchUserVotes(cycleId || ''),
@@ -71,6 +71,12 @@ function Cycle() {
     column: 'numOfVotes',
     order: 'desc',
   });
+
+  useEffect(() => {
+    if (cycle?.status === 'CLOSED') {
+      redirect(`/events/${eventId}/cycles/${cycleId}/results`);
+    }
+  }, [cycle?.status]);
 
   useEffect(() => {
     if (cycle && cycle.startAt && cycle.endAt) {

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -76,7 +76,9 @@ function Cycle() {
 
   useEffect(() => {
     if (cycle?.status === 'CLOSED') {
-      toast.success('Cycle has closed. Redirecting to the results page.');
+      toast('Cycle has closed. Redirecting to the results page.', {
+        icon: '⌛️',
+      });
       navigate(`/events/${eventId}/cycles/${cycleId}/results`);
     }
   }, [cycle?.status]);

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -76,6 +76,7 @@ function Cycle() {
 
   useEffect(() => {
     if (cycle?.status === 'CLOSED') {
+      toast.success('Cycle has closed. Redirecting to the results page.');
       navigate(`/events/${eventId}/cycles/${cycleId}/results`);
     }
   }, [cycle?.status]);

--- a/packages/berlin/src/pages/Results.tsx
+++ b/packages/berlin/src/pages/Results.tsx
@@ -14,7 +14,7 @@ import { FINAL_QUESTION_TITLE } from '../utils/constants';
 function Results() {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
 
-  const { cycleId } = useParams();
+  const { eventId, cycleId } = useParams();
 
   const { data: cycle } = useQuery({
     queryKey: ['cycles', cycleId],
@@ -70,7 +70,7 @@ function Results() {
 
   return (
     <FlexColumn $gap="2rem">
-      <BackButton />
+      <BackButton fallbackRoute={`/events/${eventId}/cycles`} />
       <Subtitle>Results for: {cycle?.forumQuestions?.[0].questionTitle}</Subtitle>
       <FlexColumn $gap="0">
         <ResultsColumns $showFunding={!!funding} />


### PR DESCRIPTION
## Closes: #561

Shows the message `Agenda has closed. Redirecting to results.`
This PR also repositions the agenda button in the mobile navigation to match its location on the desktop version.
