### PR TITLE
609 two steps group registration form

### DIFF
--- a/packages/berlin/src/components/dots/Dots.tsx
+++ b/packages/berlin/src/components/dots/Dots.tsx
@@ -4,14 +4,14 @@ import { Dot } from './Dots.styled';
 type DotsProps = {
   dots: number;
   activeDotIndex: number;
-  setStep: React.Dispatch<React.SetStateAction<number>>;
+  handleClick: (index: number) => void;
 };
 
-function Dots({ dots, activeDotIndex, setStep }: DotsProps) {
+function Dots({ dots, activeDotIndex, handleClick }: DotsProps) {
   return (
     <FlexRow>
       {Array.from({ length: dots }).map((_, index) => (
-        <Dot key={index} $active={index === activeDotIndex} onClick={() => setStep(index)} />
+        <Dot key={index} $active={index === activeDotIndex} onClick={() => handleClick(index)} />
       ))}
     </FlexRow>
   );

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -1,7 +1,10 @@
 // React and third-party libraries
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  // useLocation,
+  useNavigate,
+} from 'react-router-dom';
 
 // Store
 import { useAppStore } from '../../store';
@@ -42,7 +45,7 @@ import IconButton from '../icon-button';
 function Header() {
   const queryClient = useQueryClient();
   const { user } = useUser();
-  const location = useLocation();
+  // const location = useLocation();
   const theme = useAppStore((state) => state.theme);
   const toggleTheme = useAppStore((state) => state.toggleTheme);
   const navigate = useNavigate();
@@ -83,12 +86,12 @@ function Header() {
       <HeaderContainer>
         <LogoContainer onClick={() => navigate('/')}>
           <img src={`/logos/lexicon-${theme}.svg`} alt="Lexicon Logo" height={64} width={64} />
-          {location.pathname === '/' && (
-            <LogoTextContainer>
-              <LogoTitle>{header.title}</LogoTitle>
-              <LogoSubtitle>{header.subtitle}</LogoSubtitle>
-            </LogoTextContainer>
-          )}
+          {/* {location.pathname === '/' && ( */}
+          <LogoTextContainer>
+            <LogoTitle>{header.title}</LogoTitle>
+            <LogoSubtitle>{header.subtitle}</LogoSubtitle>
+          </LogoTextContainer>
+          {/* )} */}
         </LogoContainer>
         <NavContainer>
           <NavButtons>

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -45,7 +45,6 @@ import IconButton from '../icon-button';
 function Header() {
   const queryClient = useQueryClient();
   const { user } = useUser();
-  // const location = useLocation();
   const theme = useAppStore((state) => state.theme);
   const toggleTheme = useAppStore((state) => state.toggleTheme);
   const navigate = useNavigate();
@@ -86,12 +85,10 @@ function Header() {
       <HeaderContainer>
         <LogoContainer onClick={() => navigate('/')}>
           <img src={`/logos/lexicon-${theme}.svg`} alt="Lexicon Logo" height={64} width={64} />
-          {/* {location.pathname === '/' && ( */}
           <LogoTextContainer>
             <LogoTitle>{header.title}</LogoTitle>
             <LogoSubtitle>{header.subtitle}</LogoSubtitle>
           </LogoTextContainer>
-          {/* )} */}
         </LogoContainer>
         <NavContainer>
           <NavButtons>

--- a/packages/berlin/src/pages/Onboarding.tsx
+++ b/packages/berlin/src/pages/Onboarding.tsx
@@ -56,7 +56,7 @@ function Onboarding() {
       <FlexColumn $gap="3rem">
         <Subtitle>{data[step].title}</Subtitle>
         <BodyContent content={data[step].body} />
-        <Dots dots={data.length} activeDotIndex={step} setStep={setStep} />
+        <Dots dots={data.length} activeDotIndex={step} handleClick={(i) => setStep(i)} />
         <FlexRow>
           <Button onClick={handleSkip} $color="secondary">
             Skip


### PR DESCRIPTION
## Closes: #609 

Adds <Dots /> component to Register paga, which renders SelectEventGroup selection or RegisterForm based on the current step, a local state.

**This PR also comments the logic for showing Header Title and Subtitle at landing page, which looked like this:**

![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/c464bcbb-a5fe-4e96-958d-6287380e5712)


## Evidence:

![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/6ea5b427-078b-4632-abfb-f15ca9ee5271)

Shows a Skip button after first group selection

![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/bac3622f-0c84-41ae-abd1-b8866f510bec)

Navigation by clicking dots is enabled

![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/f0066077-a308-403b-8762-5c7812ef6586)

