### PR TITLE
naming changes

### DIFF
--- a/packages/berlin/src/components/columns/cycle-columns/CycleColumns.tsx
+++ b/packages/berlin/src/components/columns/cycle-columns/CycleColumns.tsx
@@ -11,7 +11,7 @@ function CycleColumns({ onColumnClick, showScore }: CycleColumnsProps) {
   return (
     <Card>
       <Proposal>
-        <Body>Artefact</Body>
+        <Body>Vote Items</Body>
       </Proposal>
       <Lead onClick={() => onColumnClick('lead')}>
         <Body>Creator</Body>

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -311,7 +311,7 @@ function Cycle() {
       content: (
         <OnboardingCard>
           <Subtitle>Voting Page</Subtitle>
-          <Body>View artifacts and allocate your hearts.</Body>
+          <Body>View vote items and allocate your hearts.</Body>
         </OnboardingCard>
       ),
       placement: 'center',
@@ -338,7 +338,7 @@ function Cycle() {
                 $height={16}
               />
             </FlexColumn>
-            <Body>Upvote or downvote an artifact.</Body>
+            <Body>Upvote or downvote a vote item.</Body>
           </FlexRow>
         </OnboardingCard>
       ),
@@ -365,7 +365,7 @@ function Cycle() {
       content: (
         <OnboardingCard>
           <Subtitle>Information</Subtitle>
-          <Body>View artifact and creator.</Body>
+          <Body>View vote item and creator.</Body>
           <FlexRow>
             <IconButton
               $padding={0}
@@ -374,7 +374,7 @@ function Cycle() {
               $width={24}
               $height={24}
             />
-            <Body>Current number of hearts allocated to this artifact.</Body>
+            <Body>Current number of hearts allocated to this vote item.</Body>
           </FlexRow>
         </OnboardingCard>
       ),
@@ -406,7 +406,7 @@ function Cycle() {
       target: '.step-6',
       content: (
         <OnboardingCard>
-          <Subtitle>Expand an arifact</Subtitle>
+          <Subtitle>Expand a vote item</Subtitle>
           <FlexRow>
             <IconButton
               $padding={0}
@@ -415,7 +415,7 @@ function Cycle() {
               $width={24}
               $height={24}
             />
-            <Body>Click to view the artifact description and other useful information.</Body>
+            <Body>Click to view the vote item description and other useful information.</Body>
           </FlexRow>
           <FlexRow>
             <IconButton

--- a/packages/berlin/src/pages/Event.tsx
+++ b/packages/berlin/src/pages/Event.tsx
@@ -34,7 +34,7 @@ const steps = [
     content: (
       <OnboardingCard>
         <Subtitle>Open Votes</Subtitle>
-        <Body>Explore current artifacts, the vote deadline, and cast your vote.</Body>
+        <Body>Explore current vote items, the vote deadline, and cast your vote.</Body>
       </OnboardingCard>
     ),
     placement: 'center',

--- a/packages/berlin/src/pages/Results.tsx
+++ b/packages/berlin/src/pages/Results.tsx
@@ -47,7 +47,7 @@ function Results() {
   const overallStatistics = [
     {
       id: 0,
-      title: 'Number of artefacts',
+      title: 'Number of vote items',
       data: statistics?.numProposals,
     },
     {
@@ -110,7 +110,7 @@ function Results() {
               $width={24}
               $height={24}
             />
-            <Body>Hearts received by an artifact</Body>
+            <Body>Hearts received by a vote item</Body>
           </FlexRow>
           <FlexRow>
             <IconButton
@@ -130,7 +130,7 @@ function Results() {
       target: '.step-3',
       content: (
         <OnboardingCard>
-          <Subtitle>Expand an Artifact</Subtitle>
+          <Subtitle>Expand a vote item</Subtitle>
           <FlexRow>
             <IconButton
               $padding={0}
@@ -140,7 +140,8 @@ function Results() {
               $height={24}
             />
             <Body>
-              Clicking this icon will display the artifact description and other useful information.
+              Clicking this icon will display the vote item description and other useful
+              information.
             </Body>
           </FlexRow>
           <FlexRow>


### PR DESCRIPTION
This PR changes "artifact" to "vote item" where applicable. The problem was that people vote on different questions. In case of edge-esmeralda artifacts and tensions. Therefore, a more general name is necesssary that fits multiple question categories.