### PR TITLE
651 remove my artefacts link from navbar

### DIFF
--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -122,9 +122,9 @@ function Header() {
                               )
                             );
                           })}
-                      <NavButton to={`/events/${events?.[0].id}/register`} $color="secondary">
+                      {/* <NavButton to={`/events/${events?.[0].id}/register`} $color="secondary">
                         My Artefacts
-                      </NavButton>
+                      </NavButton> */}
                       <NavButton to={`/events/${events?.[0].id}/cycles`} $color="secondary">
                         Vote
                       </NavButton>
@@ -181,9 +181,9 @@ function Header() {
                             )
                           );
                         })}
-                      <NavButton to={`/events/${events?.[0].id}/register`} $color="secondary">
+                      {/* <NavButton to={`/events/${events?.[0].id}/register`} $color="secondary">
                         My Artefacts
-                      </NavButton>
+                      </NavButton> */}
                       <NavButton to={`/events/${events?.[0].id}/cycles`} $color="secondary">
                         Vote
                       </NavButton>

--- a/packages/berlin/src/pages/Event.tsx
+++ b/packages/berlin/src/pages/Event.tsx
@@ -44,23 +44,29 @@ const steps = [
     content: (
       <OnboardingCard>
         <Subtitle>Closed Votes</Subtitle>
-        <Body>Review past votes and see results by clicking the 'Results' button.</Body>
+        <Body>
+          Review past votes and see results by clicking the
+          <Button $color="secondary" style={{ paddingInline: 4 }}>
+            results
+          </Button>{' '}
+          button.
+        </Body>
       </OnboardingCard>
     ),
     placement: 'center',
   },
+  // {
+  //   target: '.step-4',
+  //   content: (
+  //     <OnboardingCard>
+  //       <Subtitle>You can also create and join Groups</Subtitle>
+  //       <Body>You can link your artefacts to your group via My Artefacts.</Body>
+  //     </OnboardingCard>
+  //   ),
+  //   placement: 'center',
+  // },
   {
     target: '.step-4',
-    content: (
-      <OnboardingCard>
-        <Subtitle>You can also create and join Groups</Subtitle>
-        <Body>You can link your artefacts to your group via My Artefacts.</Body>
-      </OnboardingCard>
-    ),
-    placement: 'center',
-  },
-  {
-    target: '.step-5',
     content: (
       <OnboardingCard>
         <Subtitle>Event Information</Subtitle>
@@ -104,7 +110,7 @@ function Event() {
   return (
     <>
       <Onboarding type="event" steps={steps} />
-      <FlexColumn $gap="2rem" className="step-1 step-2 step-3 step-4 step-5">
+      <FlexColumn $gap="2rem" className="step-1 step-2 step-3 step-4">
         {!!openCycles?.length && <CycleTable cycles={openCycles} status="open" />}
         {!!closedCycles?.length && <CycleTable cycles={closedCycles} status="closed" />}
         {event && <EventCard event={event} />}


### PR DESCRIPTION
## Closes: #651

Comment `My artefacts` link from desktop and mobile navbar, and from voting onboarding.
Changed the 'Results' button to an actual <Button> tag on voting onboarding