### PR TITLE
647 check mardown support for registration field

### DIFF
--- a/packages/berlin/src/components/option-card/OptionCard.tsx
+++ b/packages/berlin/src/components/option-card/OptionCard.tsx
@@ -1,3 +1,22 @@
+// React and third-party libraries
+import { useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Markdown from 'react-markdown';
+
+// Store
+import { useAppStore } from '../../store';
+
+// API
+import { fetchOptionUsers, GetCycleResponse } from 'api';
+
+// Components
+import { Body } from '../typography/Body.styled';
+import { Bold } from '../typography/Bold.styled';
+import { FlexColumn } from '../containers/FlexColumn.styled';
+import IconButton from '../icon-button';
+
+// Styled Components
 import {
   ArrowDownIcon,
   ArrowIcon,
@@ -11,15 +30,7 @@ import {
   Votes,
   VotesIcon,
 } from './OptionCard.styled';
-import { Body } from '../typography/Body.styled';
-import { Bold } from '../typography/Bold.styled';
-import { FlexColumn } from '../containers/FlexColumn.styled';
-import { fetchOptionUsers, GetCycleResponse } from 'api';
-import { useAppStore } from '../../store';
-import { useNavigate, useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
-import IconButton from '../icon-button';
+import Link from '../link';
 
 type OptionCardProps = {
   option: GetCycleResponse['forumQuestions'][number]['questionOptions'][number];
@@ -153,7 +164,16 @@ function OptionCard({
               <Bold>Funding request:</Bold> {option.fundingRequest}
             </Body>
           )}
-          {option.optionSubTitle && <Body>{option.optionSubTitle}</Body>}
+          {option.optionSubTitle && (
+            <Markdown
+              components={{
+                a: ({ node, ...props }) => <Link to={props.href ?? ''}>{props.children}</Link>,
+                p: ({ node, ...props }) => <Body>{props.children}</Body>,
+              }}
+            >
+              {option.optionSubTitle}
+            </Markdown>
+          )}
           <IconButton
             $padding={0}
             $color="secondary"

--- a/packages/berlin/src/components/tables/results-table/ResultsTable.tsx
+++ b/packages/berlin/src/components/tables/results-table/ResultsTable.tsx
@@ -18,6 +18,8 @@ import { Bold } from '../../typography/Bold.styled';
 // Styled Components
 import { useNavigate } from 'react-router-dom';
 import { Card, Funding, Icon, Plurality, TitleContainer } from './ResultsTable.styled';
+import Markdown from 'react-markdown';
+import Link from '@/components/link';
 
 type ResultsTableProps = {
   $expanded: boolean;
@@ -139,7 +141,16 @@ function ResultsTable({ $expanded, option, onClick, cycleId, eventId }: ResultsT
         />
       </Funding>
       <FlexColumn className="description">
-        <Body>{option.optionSubTitle}</Body>
+        {option.optionSubTitle && (
+          <Markdown
+            components={{
+              a: ({ node, ...props }) => <Link to={props.href ?? ''}>{props.children}</Link>,
+              p: ({ node, ...props }) => <Body>{props.children}</Body>,
+            }}
+          >
+            {option.optionSubTitle}
+          </Markdown>
+        )}
         <Body>
           <Bold>Creator:</Bold> {optionUsers?.user?.firstName} {optionUsers?.user?.lastName}
         </Body>


### PR DESCRIPTION
## Closes: #647

Add markdown support for both voting an results page:

## Evidence:
![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/a928cf04-ee3e-4156-96bc-d8d1e0a3fdc5)

![image](https://github.com/lexicongovernance/pluraltools-frontend/assets/59750365/c0b5d49f-06d1-4ec5-b962-3becaacef455)
