### PR TITLE
Diego/fix holding page flash

### DIFF
--- a/packages/berlin/src/_components/ui/skeleton.tsx
+++ b/packages/berlin/src/_components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -60,7 +60,7 @@ function Header() {
   });
 
   const { data: registrationsData } = useQuery({
-    queryKey: [user?.id, 'registrations'],
+    queryKey: ['user', user?.id, 'registrations'],
     queryFn: () => fetchUserRegistrations(user?.id ?? ''),
     enabled: !!user,
   });

--- a/packages/berlin/src/pages/Event.tsx
+++ b/packages/berlin/src/pages/Event.tsx
@@ -16,6 +16,7 @@ import Button from '../components/button';
 import EventCard from '../components/event-card';
 import Link from '../components/link';
 import Onboarding from '../components/onboarding';
+import { Skeleton } from '@/_components/ui/skeleton';
 
 const steps = [
   {
@@ -81,14 +82,14 @@ const steps = [
 function Event() {
   const navigate = useNavigate();
   const { eventId } = useParams();
-  const { data: event } = useQuery({
+  const { data: event, isLoading: eventIsLoading } = useQuery({
     queryKey: ['event', eventId],
     queryFn: () => fetchEvent(eventId || ''),
     enabled: !!eventId,
   });
 
-  const { data: eventCycles } = useQuery({
-    queryKey: ['events', eventId, 'cycles'],
+  const { data: eventCycles, isLoading: cycleIsLoading } = useQuery({
+    queryKey: ['event', eventId, 'cycles'],
     queryFn: () => fetchEventCycles(eventId || ''),
     enabled: !!eventId,
     refetchInterval: 5000, // Poll every 5 seconds
@@ -111,9 +112,19 @@ function Event() {
     <>
       <Onboarding type="event" steps={steps} />
       <FlexColumn $gap="2rem" className="step-1 step-2 step-3 step-4">
-        {!!openCycles?.length && <CycleTable cycles={openCycles} status="open" />}
-        {!!closedCycles?.length && <CycleTable cycles={closedCycles} status="closed" />}
-        {event && <EventCard event={event} />}
+        {cycleIsLoading || !eventCycles ? (
+          <Skeleton className="bg-background h-[200px] min-w-full rounded-xl" />
+        ) : (
+          <>
+            {!!openCycles?.length && <CycleTable cycles={openCycles} status="open" />}
+            {!!closedCycles?.length && <CycleTable cycles={closedCycles} status="closed" />}
+          </>
+        )}
+        {eventIsLoading || !event ? (
+          <Skeleton className="bg-background h-[250px] min-w-full rounded-xl" />
+        ) : (
+          <EventCard event={event} />
+        )}
         <Body>
           Click to revisit the community’s{' '}
           <Link to="#" onClick={handleDataPolicyClick}>

--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -195,7 +195,7 @@ const CarouselWrapper = ({
     navigate(`/events/${eventId}/cycles`);
   };
 
-  const { mutate: postRegistrationMutation } = useMutation({
+  const { mutateAsync: postRegistrationMutation } = useMutation({
     mutationFn: postRegistration,
     onSuccess: async (body) => {
       if (body) {
@@ -219,7 +219,7 @@ const CarouselWrapper = ({
     },
   });
 
-  const { mutate: updateRegistrationMutation } = useMutation({
+  const { mutateAsync: updateRegistrationMutation } = useMutation({
     mutationFn: putRegistration,
     onSuccess: async (body) => {
       if (body) {
@@ -238,11 +238,11 @@ const CarouselWrapper = ({
     },
   });
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     const foundRegistration = registrations?.find((reg) => reg.status === 'DRAFT');
 
     if (foundRegistration) {
-      updateRegistrationMutation({
+      await updateRegistrationMutation({
         registrationId: foundRegistration.id || '',
         body: {
           eventId: event?.id || '',
@@ -252,7 +252,7 @@ const CarouselWrapper = ({
         },
       });
     } else {
-      postRegistrationMutation({
+      await postRegistrationMutation({
         body: {
           eventId: event?.id || '',
           groupId: null,

--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -287,9 +287,9 @@ const CarouselWrapper = ({
               groupCategories={groupCategories}
               usersToGroups={usersToGroups}
               user={user}
-              onStepComplete={() => {
+              onStepComplete={async () => {
                 if (isLastStep) {
-                  onSubmit();
+                  await onSubmit();
                 }
 
                 onStepComplete();
@@ -532,7 +532,7 @@ function EventGroupsForm({
   groupCategories: GetGroupCategoriesResponse | null | undefined;
   usersToGroups: GetUsersToGroupsResponse | null | undefined;
   user: GetUserResponse | null | undefined;
-  onStepComplete?: () => void;
+  onStepComplete?: () => Promise<void>;
 }) {
   const queryClient = useQueryClient();
   const form = useForm({
@@ -594,7 +594,7 @@ function EventGroupsForm({
     enabled: !!tensionsGroupCategory?.id,
   });
 
-  const onSubmit = (values: Record<string, string[]>) => {
+  const onSubmit = async (values: Record<string, string[]>) => {
     const formGroupIds = Object.values<string[]>(values).flat();
     const previousGroupIds = usersToGroups?.map((userToGroup) => userToGroup.group.id) || [];
 
@@ -613,7 +613,7 @@ function EventGroupsForm({
       }
     }
 
-    onStepComplete?.();
+    await onStepComplete?.();
   };
 
   return (

--- a/packages/berlin/src/pages/Register.tsx
+++ b/packages/berlin/src/pages/Register.tsx
@@ -817,7 +817,7 @@ function DynamicRegistrationFieldsForm(props: {
         // invalidate user registrations, this is for the 1 event use case
         // where the authentication is because you are approved to the event
         await queryClient.invalidateQueries({
-          queryKey: [props.user?.id, 'registrations'],
+          queryKey: ['user', props.user?.id, 'registrations'],
         });
 
         props.onRegistrationFormCreate?.(body.id);


### PR DESCRIPTION
## overview
should remove flash of holding page


### loading states
in order to stop a moment where text would flash on the event page i added a loading state on each component.

the interesting thing about this solution is that initially the plan was to just have a boolean that would work like:

```
  if (eventIsLoading || cycleIsLoading) {
    return <Skeleton className="bg-background h-[400px] max-w-full rounded-xl" />;
  }
```

but this would never show up, it would show up if i made the condition truthy but there was still a flash where there was no skeleton and a text show up

solution that actually worked
```
 {cycleIsLoading || !eventCycles ? (
          <Skeleton className="bg-background h-[200px] min-w-full rounded-xl" />
        ) : (
          <>
            {!!openCycles?.length && <CycleTable cycles={openCycles} status="open" />}
            {!!closedCycles?.length && <CycleTable cycles={closedCycles} status="closed" />}
          </>
        )}
        {eventIsLoading || !event ? (
          <Skeleton className="bg-background h-[250px] min-w-full rounded-xl" />
        ) : (
          <EventCard event={event} />
        )}
```

not as clean as the last solution. there's probably a better solution to this and an explanation but i can't seem to find one