### PR TITLE
Fix vote state

### DIFF
--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -59,7 +59,6 @@ function Cycle() {
     queryKey: ['votes', cycleId],
     queryFn: () => fetchUserVotes(cycleId || ''),
     enabled: !!user?.id && !!cycleId,
-    retry: false,
   });
 
   const availableHearts =
@@ -129,17 +128,16 @@ function Cycle() {
     }
   }, [cycleState, time, formattedTime]);
 
-  const updateInitialVotesAndHearts = (votes: GetUserVotesResponse) => {
-    const givenVotes = votes
-      .map((option) => option.numOfVotes)
-      .reduce((prev, curr) => prev + curr, 0);
+  const updateInitialVotesAndHearts = (votes: GetUserVotesResponse | null | undefined) => {
+    const givenVotes =
+      votes?.map((option) => option.numOfVotes).reduce((prev, curr) => prev + curr, 0) ?? 0;
 
     setAvailableHearts({
       questionId: cycle?.forumQuestions[0].id || '',
       hearts: Math.max(0, INITIAL_HEARTS - givenVotes),
     });
 
-    setLocalUserVotes(votes);
+    setLocalUserVotes(votes ?? []);
   };
 
   const votesAreDifferent = useMemo(() => {
@@ -160,9 +158,7 @@ function Cycle() {
   }, [localUserVotes, userVotes]);
 
   useEffect(() => {
-    if (userVotes?.length) {
-      updateInitialVotesAndHearts(userVotes);
-    }
+    updateInitialVotesAndHearts(userVotes);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userVotes]);
 

--- a/packages/berlin/src/store/index.ts
+++ b/packages/berlin/src/store/index.ts
@@ -29,7 +29,6 @@ export const useAppStore = create<AppState>()(
     persist(
       (set) => ({
         userStatus: 'INCOMPLETE',
-        eventRegistrationStatus: 'INCOMPLETE',
         onboardingStatus: {
           event: 'INCOMPLETE',
           cycle: 'INCOMPLETE',
@@ -55,7 +54,15 @@ export const useAppStore = create<AppState>()(
             availableHearts: {},
           })),
       }),
-      { name: 'lexicon-store' },
+      {
+        name: 'lexicon-store',
+        // Partialize the store to only persist the required keys
+        partialize: (state) => ({
+          onboardingStatus: state.onboardingStatus,
+          userStatus: state.userStatus,
+          theme: state.theme,
+        }),
+      },
     ),
   ),
 );

--- a/packages/berlin/src/utils/voting.ts
+++ b/packages/berlin/src/utils/voting.ts
@@ -1,11 +1,10 @@
 import { GetUserVotesResponse, PostVotesRequest } from 'api';
-import { ResponseUserVotesType } from '../types/CycleType';
 import toast from 'react-hot-toast';
 import { INITIAL_HEARTS } from './constants';
 
 export const handleLocalVote = (
   optionId: string,
-  prevLocalUserVotes: ResponseUserVotesType | { optionId: string; numOfVotes: number }[],
+  prevLocalUserVotes: GetUserVotesResponse | { optionId: string; numOfVotes: number }[],
 ) => {
   // find if the user has already voted for this option
   const prevVote = prevLocalUserVotes.find((x) => x.optionId === optionId);
@@ -28,7 +27,7 @@ export const handleLocalVote = (
 
 export const handleLocalUnVote = (
   optionId: string,
-  prevLocalUserVotes: ResponseUserVotesType | { optionId: string; numOfVotes: number }[],
+  prevLocalUserVotes: GetUserVotesResponse | { optionId: string; numOfVotes: number }[],
 ) => {
   // this will just find the option and decrease the number of votes by 1
   const updatedLocalVotes = prevLocalUserVotes.map((prevLocalUserVote) => {
@@ -53,7 +52,7 @@ export const handleAvailableHearts = (availableHearts: number, type: 'vote' | 'u
 export const handleSaveVotes = (
   userVotes: GetUserVotesResponse | null | undefined,
   localUserVotes:
-    | ResponseUserVotesType
+    | GetUserVotesResponse
     | {
         optionId: string;
         numOfVotes: number;


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-frontend/issues/628

## overview
stops storing user votes in local storage and recalculates them on each load of the cycle