### PR TITLE
update groups reg to be under event url

### DIFF
--- a/packages/berlin/src/App.tsx
+++ b/packages/berlin/src/App.tsx
@@ -232,14 +232,6 @@ const router = (queryClient: QueryClient) =>
               Component: Account,
             },
             {
-              path: '/secret-groups',
-              Component: SecretGroupRegistration,
-            },
-            {
-              path: '/public-groups',
-              Component: PublicGroupRegistration,
-            },
-            {
               path: '/events',
               children: [
                 {
@@ -254,6 +246,14 @@ const router = (queryClient: QueryClient) =>
                 {
                   path: ':eventId/holding',
                   Component: Holding,
+                },
+                {
+                  path: ':eventId/secret-groups',
+                  Component: SecretGroupRegistration,
+                },
+                {
+                  path: ':eventId/public-groups',
+                  Component: PublicGroupRegistration,
                 },
                 {
                   loader: ({ params }) =>


### PR DESCRIPTION
## overview
the reason behind this is to fix that when i click groups the navbar would have changed to the global links and not the event links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced routing structure to improve navigation by nesting group registration paths under specific events.
	- Updated routes for `SecretGroupRegistration` and `PublicGroupRegistration` to be accessed via `:eventId/secret-groups` and `:eventId/public-groups`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->