### PR TITLE
731 update event page

### DIFF
--- a/packages/api/src/types/Events.ts
+++ b/packages/api/src/types/Events.ts
@@ -9,6 +9,7 @@ export type GetEventResponse = {
   description: string | null;
   fields: unknown;
   status: 'OPEN' | 'CLOSED' | 'UPCOMING' | null;
+  eventDisplayRank: number | null;
 };
 
 export type GetEventsResponse = GetEventResponse[];

--- a/packages/berlin/src/components/events/Events.tsx
+++ b/packages/berlin/src/components/events/Events.tsx
@@ -2,14 +2,14 @@
 import { useNavigate } from 'react-router-dom';
 
 // API
-import { GetEventResponse } from 'api';
+import { GetEventsResponse } from 'api';
 
 // Components
 import { Body } from '../typography/Body.styled';
 import { Subtitle } from '../typography/Subtitle.styled';
 
 type EventsProps = {
-  events: GetEventResponse[] | undefined;
+  events: GetEventsResponse | null | undefined;
   errorMessage: string;
 };
 
@@ -20,8 +20,14 @@ export default function Events({ events, errorMessage }: EventsProps) {
     navigate(`/events/${eventId}/cycles`);
   };
 
-  return events?.length ? (
-    events.map((event) => {
+  const sortedEvents = events?.sort((a, b) => {
+    const rankA = a.eventDisplayRank ?? Number.MAX_SAFE_INTEGER;
+    const rankB = b.eventDisplayRank ?? Number.MAX_SAFE_INTEGER;
+    return rankA - rankB;
+  });
+
+  return sortedEvents?.length ? (
+    sortedEvents.map((event) => {
       return (
         <article
           key={event.id}

--- a/packages/berlin/src/pages/Events.tsx
+++ b/packages/berlin/src/pages/Events.tsx
@@ -1,5 +1,4 @@
 // React and third-party libraries
-import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 // API
@@ -11,11 +10,9 @@ import useUser from '../hooks/useUser';
 // Components
 import { FlexColumn } from '../components/containers/FlexColumn.styled';
 import { Title } from '../components/typography/Title.styled';
-import * as Tabs from '../components/tabs';
 import EventsCards from '../components/events';
 
 function Events() {
-  const [activeTab, setActiveTab] = useState<string>('upcoming');
   const { user } = useUser();
   const { data: events } = useQuery({
     queryKey: ['events'],
@@ -23,26 +20,13 @@ function Events() {
     enabled: !!user?.id,
   });
 
-  const openEvents = useMemo(() => events?.filter((event) => event.status === 'OPEN'), [events]);
-  const closedEvents = useMemo(
-    () => events?.filter((events) => events.status === 'CLOSED'),
-    [events],
-  );
-
-  const tabNames = ['upcoming', 'past'];
-  const tabs = {
-    upcoming: <EventsCards events={openEvents} errorMessage="No upcoming events..." />,
-    past: <EventsCards events={closedEvents} errorMessage="No past events..." />,
-  };
-
   return (
     <FlexColumn $gap="2rem">
       <section className="flex w-full flex-col justify-between gap-2 md:flex-row md:items-center">
         <Title>Events</Title>
-        <Tabs.TabsHeader className="tabs" tabNames={tabNames} onTabChange={setActiveTab} />
       </section>
       <section className="grid w-full gap-4 md:grid-cols-2">
-        <Tabs.TabsManager tabs={tabs} tab={activeTab} fallback={'Tab not found'} />
+        <EventsCards events={events} errorMessage="No events found..." />
       </section>
     </FlexColumn>
   );


### PR DESCRIPTION
## Closes: #731

Sort events by `eventDisplayRank` and remove `upcoming/closed` tabs from events page

## Evidence:
![image](https://github.com/user-attachments/assets/fabd998b-6d3b-47ae-988e-00b7023ae7c0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an event ranking system with the new `eventDisplayRank` property to enhance event sorting.
  - Simplified the `Events` component by removing tab navigation, allowing direct rendering of all events.

- **Bug Fixes**
  - Improved sorting logic to correctly classify events without ranks, ensuring they appear at the end of the list.

- **Refactor**
  - Updated the data structure for event props, shifting from an array to a single response object for better data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->