### PR TITLE
Add skeleton to events

### DIFF
--- a/packages/berlin/src/components/skeleton/Skeleton.tsx
+++ b/packages/berlin/src/components/skeleton/Skeleton.tsx
@@ -1,0 +1,8 @@
+import { useAppStore } from '@/store';
+
+export default function Skeleton({ className }: React.HTMLAttributes<HTMLDivElement>) {
+  const theme = useAppStore((state) => state.theme);
+  return (
+    <div className={`${className} animate-pulse ${theme === 'dark' ? 'bg-[#333]' : 'bg-[#eee]'}`} />
+  );
+}

--- a/packages/berlin/src/components/skeleton/index.ts
+++ b/packages/berlin/src/components/skeleton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Skeleton';

--- a/packages/berlin/src/pages/Event.tsx
+++ b/packages/berlin/src/pages/Event.tsx
@@ -17,10 +17,11 @@ import Cycles from '../components/cycles';
 import Link from '../components/link';
 import Markdown from 'react-markdown';
 import Onboarding from '@/components/onboarding';
+import Skeleton from '@/components/skeleton';
 
 function Event() {
   const { eventId } = useParams();
-  const { data: event } = useQuery({
+  const { data: event, isLoading } = useQuery({
     queryKey: ['event', eventId],
     queryFn: () =>
       fetchEvent({ eventId: eventId || '', serverUrl: import.meta.env.VITE_SERVER_URL }),
@@ -48,6 +49,19 @@ function Event() {
     () => (openCycles && openCycles.length > 0 ? 'upcoming' : 'past'),
     [openCycles],
   );
+
+  if (isLoading) {
+    return (
+      <div className="grid w-full grid-cols-3 gap-4">
+        <div className="col-span-3 flex flex-col gap-4 md:col-span-2">
+          <Skeleton className="h-[100px] md:h-[212px]" />
+          <Skeleton className="h-[50px] md:h-[122px]" />
+        </div>
+        <Skeleton className="col-span-3 h-[250px] md:col-span-1 md:h-[350px]" />
+        <Skeleton className="col-span-3 h-[200px]" />
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
Adds skeleton to events page, working for mobile and desktop.

## Evidence:
<img width="1179" alt="Screenshot 2024-08-06 at 11 31 56 AM" src="https://github.com/user-attachments/assets/d92a8339-2cca-4969-a140-d9a00406cd5d">
<img width="323" alt="Screenshot 2024-08-06 at 11 32 15 AM" src="https://github.com/user-attachments/assets/55a10e0b-918f-4f7d-b65e-db98665c7b08">
