### PR TITLE
rename vote items to vote options

### DIFF
--- a/packages/berlin/src/components/cycles/Cycles.tsx
+++ b/packages/berlin/src/components/cycles/Cycles.tsx
@@ -17,11 +17,6 @@ type CyclesProps = {
 function Cycles({ cycles, eventId, fallback }: CyclesProps) {
   const navigate = useNavigate();
 
-  const formatDate = (date: string) => {
-    const eventEndDate = new Date(date);
-    return new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(eventEndDate);
-  };
-
   const handleCycleClick = (cycleId: string) => {
     navigate(`/events/${eventId}/cycles/${cycleId}`);
   };
@@ -36,7 +31,6 @@ function Cycles({ cycles, eventId, fallback }: CyclesProps) {
             onClick={() => handleCycleClick(cycle.id)}
           >
             <Body>{cycle?.questions[0]?.title}</Body>
-            <Body>{formatDate(cycle.endAt)}</Body>
           </article>
         ))
       ) : (

--- a/packages/berlin/src/pages/Cycle.tsx
+++ b/packages/berlin/src/pages/Cycle.tsx
@@ -326,7 +326,7 @@ function Cycle() {
         {currentCycle?.options.length ? (
           <FlexColumn>
             <div className="flex w-full items-center justify-between">
-              <Subtitle>Vote items</Subtitle>
+              <Subtitle>Vote options</Subtitle>
               <div className="flex cursor-pointer items-center gap-2">
                 <Body>Sort</Body>
                 <DropdownMenu>


### PR DESCRIPTION
## overview
- removed date from option cards in cycle
- rename vote items to vote options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `Subtitle` in the Cycle page for enhanced clarity, changing "Vote items" to "Vote options."

- **Bug Fixes**
	- Removed the `formatDate` function from the `Cycles` component, simplifying the rendering process, though it may reduce the displayed information about cycle end dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->